### PR TITLE
chore(ci): add caching to mobile client CI

### DIFF
--- a/.github/workflows/flutter_android_build.yml
+++ b/.github/workflows/flutter_android_build.yml
@@ -34,9 +34,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+        cache: 'gradle'
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.27.1'
+        cache: true
     - name: Prepare Flutter Build
       env:
         ANDROID_KEYSTORE_STRING: ${{ secrets.ANDROID_KEYSTORE }}

--- a/.github/workflows/flutter_browserstack_android.yml
+++ b/.github/workflows/flutter_browserstack_android.yml
@@ -37,9 +37,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+        cache: 'gradle'
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.27.1'
+        cache: true
     - name: Prepare Flutter Build
       env:
         ANDROID_KEYSTORE_STRING: ${{ secrets.ANDROID_KEYSTORE }}

--- a/.github/workflows/flutter_browserstack_ios.yml
+++ b/.github/workflows/flutter_browserstack_ios.yml
@@ -38,13 +38,10 @@ jobs:
       with:
         # Starting from xcode 15 there is a issue with integration tests running longer then ~6 minutes (https://github.com/flutter/flutter/issues/145143)
         xcode-version: 14.3.1
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.27.1'
+        cache: true
     - run: flutter pub get
     - run: flutter pub run build_runner build --delete-conflicting-outputs
     - shell: bash

--- a/.github/workflows/flutter_build_test_analyze.yml
+++ b/.github/workflows/flutter_build_test_analyze.yml
@@ -34,9 +34,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+        cache: 'gradle'
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.27.1'
+        cache: true
     - name: Prepare Flutter Build
       run: |
         flutter pub get

--- a/.github/workflows/flutter_ios_build.yml
+++ b/.github/workflows/flutter_ios_build.yml
@@ -30,13 +30,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.27.1'
+        cache: true
     - name: Prepare Flutter Build
       run: |
         flutter pub get

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,13 +42,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.1'
+          cache: true
       - name: Install the Apple signing certificate and appstore connect key
         env:
           SBB_APPSTORE_BASE64: ${{ secrets.SBB_APPSTORE_BASE64 }}
@@ -136,9 +133,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.1'
+          cache: true
       - name: Prepare Flutter Android Build
         env:
           ANDROID_KEYSTORE_STRING: ${{ secrets.ANDROID_KEYSTORE }}


### PR DESCRIPTION
This PR aims at shortening the mobile CI / CD workflows. 

It adds caching to the mobile client CI / CD.
It also removes unnecessary java setups where not needed (if no Android build is being done).

Expected time reductions for workflows **(rough estimate)**:

- `release-please.yml`: 1 min (android), 1:30 min (iOS)
- `flutter_ios_build.yml`: 1 min
- `flutter_build_test_analyze`: 30 sec
- `flutter_browserstack_android.yml`: ~1 min
- `flutter_android_build.yml`: ~1 min

The time reductions will only show in full effect once the caching has happened on the main branch.