### PR TITLE
chore(ci): add workflow linting

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,14 @@
+# Configuration variables in array of strings defined in your repository or organization.
+config-variables:
+  - DASGITHUBAPP_APPID
+
+# Path-specific configurations.
+paths:
+  # Glob pattern relative to the repository root for matching files. The path separator is always '/'.
+  # This example configures any YAML file under the '.github/workflows/' directory.
+  .github/workflows/**/*.{yml,yaml}:
+    # List of regular expressions to filter errors by the error messages.
+    ignore:
+      # Ignore the specific error from shellcheck
+      - 'shellcheck reported issue in this script: SC2086:.+' # double quote to prevent globbing and word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+' # Consider using { cmd1; cmd2; } >> file instead of individual redirects.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -47,7 +47,7 @@ jobs:
           VERSION: main
         run: |
           # Convert to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[:upper:]' '[:lower:]')
           
           mvn spring-boot:build-image \
             -Dmaven.test.skip=true \

--- a/.github/workflows/ci-linter.yml
+++ b/.github/workflows/ci-linter.yml
@@ -1,0 +1,19 @@
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+    branches: [ "main" ]
+
+jobs:
+  check-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint workflows using actionlint # https://github.com/rhysd/actionlint/tree/main
+        uses: raven-actions/actionlint@v2

--- a/.github/workflows/ci-sfera-mock.yml
+++ b/.github/workflows/ci-sfera-mock.yml
@@ -47,7 +47,7 @@ jobs:
           VERSION: main
         run: |
           # Convert to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[:upper:]' '[:lower:]')
           
           mvn spring-boot:build-image \
             -Dmaven.test.skip=true \

--- a/.github/workflows/ci-webapp.yml
+++ b/.github/workflows/ci-webapp.yml
@@ -70,7 +70,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           # Convert to lowercase
-          IMAGE_REPO=$(echo $IMAGE_REPO | tr '[A-Z]' '[a-z]')
+          IMAGE_REPO=$(echo $IMAGE_REPO | tr '[:upper:]' '[:lower:]')
           
           docker build -t $IMAGE_REPO:$IMAGE_TAG .
           docker push $IMAGE_REPO:$IMAGE_TAG

--- a/.github/workflows/release-das-client-android.yml
+++ b/.github/workflows/release-das-client-android.yml
@@ -48,6 +48,7 @@ jobs:
 
   release:
     needs: [prepare]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: das_client
@@ -67,7 +68,6 @@ jobs:
             packageName: 'ch.sbb.das.client'
             app-root: 'lib/main_prod.dart'
             release-dir: 'prodRelease/app-prod-release.aab'
-
 
 
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
           VERSION: ${{ needs.release-please.outputs.sfera_mock--version }}
         run: |
           # Convert to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[:upper:]' '[:lower:]')
           
           mvn spring-boot:build-image \
             -Dmaven.test.skip=true \
@@ -96,7 +96,7 @@ jobs:
           VERSION: ${{ needs.release-please.outputs.das_backend--version }}
         run: |
           # Convert to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[:upper:]' '[:lower:]')
 
           mvn spring-boot:build-image \
             -Dmaven.test.skip=true \
@@ -130,7 +130,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           # Convert to lowercase
-          IMAGE_REPO=$(echo $IMAGE_REPO | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[:upper:]' '[:lower:]')
 
           docker build -t $IMAGE_REPO:$IMAGE_TAG .
           docker push $IMAGE_REPO:$IMAGE_TAG


### PR DESCRIPTION

Having merged #752, I noticed that I had made a simple mistake in one of the workflows (forgot adding `runs-on`). Since there is no validation / linting enforced, this mistake went unnoticed.

This PR therefore:
* fixes the above mentioned issue
* adds a ci-linter workflow, that uses [actionlint](https://github.com/rhysd/actionlint/tree/main) to run validation and linting on pushes to the ./.github/workflows Github Actions workflows (can be and will be configured)
* makes small improvements to the existing workflows for linting to pass