### PR TITLE
chore(ci): fix issues with mobile client release

### DIFF
--- a/.github/workflows/flutter_android_build.yml
+++ b/.github/workflows/flutter_android_build.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4

--- a/.github/workflows/release-das-client-android.yml
+++ b/.github/workflows/release-das-client-android.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload generated srcs  # saves around 40 sec
         uses: actions/upload-artifact@v4
         with:
-          name: gen_srcs
+          name: gen_srcs_android
           path: |
             **/*.g.dart
             **/*.gr.dart
@@ -91,7 +91,7 @@ jobs:
       - name: Download gen srcs
         uses: actions/download-artifact@v4
         with:
-          name: gen_srcs
+          name: gen_srcs_android
 
       - name: Store secrets as env vars
         env:

--- a/.github/workflows/release-das-client-ios.yml
+++ b/.github/workflows/release-das-client-ios.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload generated srcs  # saves around 40 sec
         uses: actions/upload-artifact@v4
         with:
-          name: gen_srcs
+          name: gen_srcs_ios
           path: |
             **/*.g.dart
             **/*.gr.dart
@@ -84,7 +84,7 @@ jobs:
       - name: Download gen srcs
         uses: actions/download-artifact@v4
         with:
-          name: gen_srcs
+          name: gen_srcs_ios
 
       - name: Install Apple signing certificate and appstore connect key
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,11 +37,13 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.das_client--release_created
     uses: ./.github/workflows/release-das-client-android.yml
+    secrets: inherit
 
   das_client-release-ios:
     needs: release-please
     if: needs.release-please.outputs.das_client--release_created
     uses: ./.github/workflows/release-das-client-ios.yml
+    secrets: inherit
 
   sfera_mock-release:
     needs: release-please


### PR DESCRIPTION

- use ubuntu-latest in android builds (cheaper and more available)
- pass secrets inherently to reusable workflows
- fix collision of uploading gen srcs in android and ios workflow 