### PR TITLE
chore: rm wrong CHANGELOG sections

### DIFF
--- a/das_client/app/CHANGELOG.md
+++ b/das_client/app/CHANGELOG.md
@@ -16,15 +16,6 @@
 * planned and operational times ([#84](https://github.com/SchweizerischeBundesbahnen/DAS/issues/84)) ([#906](https://github.com/SchweizerischeBundesbahnen/DAS/issues/906)) ([54b53f3](https://github.com/SchweizerischeBundesbahnen/DAS/commit/54b53f390f08df0edffd7c583fe920ef7ae9839d))
 * warnApp sound is looped ([#876](https://github.com/SchweizerischeBundesbahnen/DAS/issues/876)) ([591281c](https://github.com/SchweizerischeBundesbahnen/DAS/commit/591281c67a5b1638360bc16e1e5be066972704f0))
 
-
-### Bug Fixes
-
-* click on radio channel header opens last service point ([#866](https://github.com/SchweizerischeBundesbahnen/DAS/issues/866)) ([c744b69](https://github.com/SchweizerischeBundesbahnen/DAS/commit/c744b69c2e4cd990536b3622c660d326acc2ee4e))
-* do not display gradient columns if modal sheet open ([#873](https://github.com/SchweizerischeBundesbahnen/DAS/issues/873)) ([f1a2894](https://github.com/SchweizerischeBundesbahnen/DAS/commit/f1a28941f4535142331eba0959b5595f4706045f))
-* icon button animation in header for pause/start button ([#497](https://github.com/SchweizerischeBundesbahnen/DAS/issues/497)) ([#872](https://github.com/SchweizerischeBundesbahnen/DAS/issues/872)) ([ded9a4a](https://github.com/SchweizerischeBundesbahnen/DAS/commit/ded9a4a9ac81fae5219544ca716dcd208166e8c9))
-* show SIM in header ([#865](https://github.com/SchweizerischeBundesbahnen/DAS/issues/865)) ([ca1ca32](https://github.com/SchweizerischeBundesbahnen/DAS/commit/ca1ca3203a735fc8bc9c6c18fbc73dc39d50f9a5))
-* small ui changes ([#875](https://github.com/SchweizerischeBundesbahnen/DAS/issues/875)) ([2abf485](https://github.com/SchweizerischeBundesbahnen/DAS/commit/2abf485655ad69d02b3d9c277c03a3513077e3a2))
-
 ## [0.18.1](https://github.com/SchweizerischeBundesbahnen/DAS/compare/das_client-v0.18.0...das_client-v0.18.1) (2025-05-13)
 
 
@@ -81,83 +72,10 @@
 ## [0.15.0](https://github.com/SchweizerischeBundesbahnen/DAS/compare/das_client-v0.14.2...das_client-v0.15.0) (2025-04-02)
 
 
-### ⚠ BREAKING CHANGES
-
-* upgrade to SFERA v3 ([#578](https://github.com/SchweizerischeBundesbahnen/DAS/issues/578)) (#577)
-
-### Features
-
-* add RADN footnotes ([#625](https://github.com/SchweizerischeBundesbahnen/DAS/issues/625)) ([#762](https://github.com/SchweizerischeBundesbahnen/DAS/issues/762)) ([3c4324f](https://github.com/SchweizerischeBundesbahnen/DAS/commit/3c4324f13b0c2c5f79fab687f55cbffa152d18f7))
-* add TMS Connection, add Prefix to flavor, implement SP Request ([#331](https://github.com/SchweizerischeBundesbahnen/DAS/issues/331)) ([25270ee](https://github.com/SchweizerischeBundesbahnen/DAS/commit/25270eeed6384bb13168ffbc8481fb366c879cc1))
-* add whistle, balise, tram area and levelcrossing ([#224](https://github.com/SchweizerischeBundesbahnen/DAS/issues/224)) ([#485](https://github.com/SchweizerischeBundesbahnen/DAS/issues/485)) ([27379a2](https://github.com/SchweizerischeBundesbahnen/DAS/commit/27379a2bbdd991db8736f57f19eadddfb3dbaf7d))
-* added CAB start and end signaling ([#82](https://github.com/SchweizerischeBundesbahnen/DAS/issues/82)) ([#442](https://github.com/SchweizerischeBundesbahnen/DAS/issues/442)) ([151f24e](https://github.com/SchweizerischeBundesbahnen/DAS/commit/151f24e1d76c2911c2061fbbc0f95f414a634903))
-* added communication network change. ([#372](https://github.com/SchweizerischeBundesbahnen/DAS/issues/372)) ([#658](https://github.com/SchweizerischeBundesbahnen/DAS/issues/658)) ([a0ef624](https://github.com/SchweizerischeBundesbahnen/DAS/commit/a0ef62444b73ca30bfc3f85b94d34ba13bc527ad))
-* added curve points and main signals to train journey ([#82](https://github.com/SchweizerischeBundesbahnen/DAS/issues/82)) ([523ecca](https://github.com/SchweizerischeBundesbahnen/DAS/commit/523eccad303bdc1be04f696605152d255df88cdd))
-* added graduated station speed. ([#82](https://github.com/SchweizerischeBundesbahnen/DAS/issues/82)) ([#484](https://github.com/SchweizerischeBundesbahnen/DAS/issues/484)) ([8af6cf9](https://github.com/SchweizerischeBundesbahnen/DAS/commit/8af6cf91a9ea22082f39df2ff73fcce215cfaea9))
-* added koa notification ([#624](https://github.com/SchweizerischeBundesbahnen/DAS/issues/624)) ([#688](https://github.com/SchweizerischeBundesbahnen/DAS/issues/688)) ([164b557](https://github.com/SchweizerischeBundesbahnen/DAS/commit/164b557ac3f824af3a1d77ce516f7c42847b9e67))
-* added next stop ([#200](https://github.com/SchweizerischeBundesbahnen/DAS/issues/200)) ([#438](https://github.com/SchweizerischeBundesbahnen/DAS/issues/438)) ([948373c](https://github.com/SchweizerischeBundesbahnen/DAS/commit/948373c0b6c99f51383fcf6f67387ddb82dfce30))
-* added punctuality display ([#122](https://github.com/SchweizerischeBundesbahnen/DAS/issues/122)) ([#473](https://github.com/SchweizerischeBundesbahnen/DAS/issues/473)) ([f9646b0](https://github.com/SchweizerischeBundesbahnen/DAS/commit/f9646b0a72915d1f6dbc2b57e530c84f14fe5762))
-* added reduced journey overview ([#626](https://github.com/SchweizerischeBundesbahnen/DAS/issues/626)) ([#691](https://github.com/SchweizerischeBundesbahnen/DAS/issues/691)) ([49adc47](https://github.com/SchweizerischeBundesbahnen/DAS/commit/49adc475b0bedfabf07730523145fcc69c91f369))
-* added visualization for single track without block equipment. ([#230](https://github.com/SchweizerischeBundesbahnen/DAS/issues/230)) ([#569](https://github.com/SchweizerischeBundesbahnen/DAS/issues/569)) ([45d2925](https://github.com/SchweizerischeBundesbahnen/DAS/commit/45d29253495367e25c8ec140ec154ad2103a8b99))
-* added visualization for two track with single track equipment. ([#82](https://github.com/SchweizerischeBundesbahnen/DAS/issues/82)) ([#536](https://github.com/SchweizerischeBundesbahnen/DAS/issues/536)) ([c20ac78](https://github.com/SchweizerischeBundesbahnen/DAS/commit/c20ac78904c43826b3d283160940761b69ffb0e6))
-* added visualization of non standard track equipment ([#82](https://github.com/SchweizerischeBundesbahnen/DAS/issues/82)) ([#470](https://github.com/SchweizerischeBundesbahnen/DAS/issues/470)) ([c4f83eb](https://github.com/SchweizerischeBundesbahnen/DAS/commit/c4f83ebc8a55929e9e38bb86837633cc901dd1cf))
-* added warn function modal sheet for ux testing. ([#623](https://github.com/SchweizerischeBundesbahnen/DAS/issues/623)) ([#679](https://github.com/SchweizerischeBundesbahnen/DAS/issues/679)) ([3d074d9](https://github.com/SchweizerischeBundesbahnen/DAS/commit/3d074d94a8823e36584a8088a408963404710f13))
-* adding navigation drawer ([#299](https://github.com/SchweizerischeBundesbahnen/DAS/issues/299)) ([8890805](https://github.com/SchweizerischeBundesbahnen/DAS/commit/8890805983adf4a26bc1fc141a8836d1c841ed1c))
-* android deployment ([#153](https://github.com/SchweizerischeBundesbahnen/DAS/issues/153)) ([7949bdf](https://github.com/SchweizerischeBundesbahnen/DAS/commit/7949bdff27a4c3cd141cdb810cd51c49537a2e7e))
-* automatische fortschaltung ([#94](https://github.com/SchweizerischeBundesbahnen/DAS/issues/94)) ([#553](https://github.com/SchweizerischeBundesbahnen/DAS/issues/553)) ([4642825](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4642825132bc223c1ce0203deaac84702c1fb8ea))
-* base structure of train journey table ([#79](https://github.com/SchweizerischeBundesbahnen/DAS/issues/79)) ([c90a5be](https://github.com/SchweizerischeBundesbahnen/DAS/commit/c90a5beb9babefdefd5fa66118fb892cfff9324e))
-* basic fahrbild header with static data and ADL notification. ([#79](https://github.com/SchweizerischeBundesbahnen/DAS/issues/79)) ([f076f44](https://github.com/SchweizerischeBundesbahnen/DAS/commit/f076f44b497cf95f64342bd8aadaee66f189ce66))
-* battery-status [#123](https://github.com/SchweizerischeBundesbahnen/DAS/issues/123) ([#574](https://github.com/SchweizerischeBundesbahnen/DAS/issues/574)) ([95ccf99](https://github.com/SchweizerischeBundesbahnen/DAS/commit/95ccf993644c5eb3ab136c2d749b17ab09954f91))
-* browserstack ([#140](https://github.com/SchweizerischeBundesbahnen/DAS/issues/140)) ([8396452](https://github.com/SchweizerischeBundesbahnen/DAS/commit/83964524f676d1e0c62581d8db545fdef22ee354))
-* changed battery status design ([#590](https://github.com/SchweizerischeBundesbahnen/DAS/issues/590)) ([#747](https://github.com/SchweizerischeBundesbahnen/DAS/issues/747)) ([9f9e563](https://github.com/SchweizerischeBundesbahnen/DAS/commit/9f9e56330d47718e70106e65020d58debec5d917))
-* curves and km-board without speed data ([#478](https://github.com/SchweizerischeBundesbahnen/DAS/issues/478)) ([#656](https://github.com/SchweizerischeBundesbahnen/DAS/issues/656)) ([2020764](https://github.com/SchweizerischeBundesbahnen/DAS/commit/2020764a51185a7de8a550a372ec16365422ef07))
-* das client durchstich ([#117](https://github.com/SchweizerischeBundesbahnen/DAS/issues/117)) ([62933d6](https://github.com/SchweizerischeBundesbahnen/DAS/commit/62933d6ddca14e7eab11d898881f2a922ceabc2c))
-* day and night mode [#102](https://github.com/SchweizerischeBundesbahnen/DAS/issues/102) ([#682](https://github.com/SchweizerischeBundesbahnen/DAS/issues/682)) ([6f34475](https://github.com/SchweizerischeBundesbahnen/DAS/commit/6f34475f528c9f96418eacc7764d4b418a9b0fad))
-* force landscape orientation ([#358](https://github.com/SchweizerischeBundesbahnen/DAS/issues/358)) ([0f80fb0](https://github.com/SchweizerischeBundesbahnen/DAS/commit/0f80fb0fa5e0b8061714c69dd9eea8fa11f87930))
-* grundaufbau mobile app ([#290](https://github.com/SchweizerischeBundesbahnen/DAS/issues/290)) ([97bfc73](https://github.com/SchweizerischeBundesbahnen/DAS/commit/97bfc73a99a53dd9ecbfa51b1be5f5d2b1abafb2))
-* hide header while train is active ([#670](https://github.com/SchweizerischeBundesbahnen/DAS/issues/670)) ([#696](https://github.com/SchweizerischeBundesbahnen/DAS/issues/696)) ([57f2bd7](https://github.com/SchweizerischeBundesbahnen/DAS/commit/57f2bd7921e0546966010b9e7f13ff52127c1e0c))
-* hide line speed and ASR above 40km/h on ETCS L2 segment. ([#120](https://github.com/SchweizerischeBundesbahnen/DAS/issues/120)) ([#586](https://github.com/SchweizerischeBundesbahnen/DAS/issues/586)) ([e197542](https://github.com/SchweizerischeBundesbahnen/DAS/commit/e197542142c262455b9b45159d5288816974c2c2))
-* implement anschlussgleise, anschlussweichen und Zahnstangen ([#136](https://github.com/SchweizerischeBundesbahnen/DAS/issues/136)) ([#447](https://github.com/SchweizerischeBundesbahnen/DAS/issues/447)) ([aee3fe1](https://github.com/SchweizerischeBundesbahnen/DAS/commit/aee3fe1ebf226a16198e76f425fd247374a998de))
-* implement betriebspunktabfolge ([#388](https://github.com/SchweizerischeBundesbahnen/DAS/issues/388)) ([9f36786](https://github.com/SchweizerischeBundesbahnen/DAS/commit/9f367865190ffc91cc492891a84a9fa24f0c3a1a))
-* implement break series selection and speed display ([#89](https://github.com/SchweizerischeBundesbahnen/DAS/issues/89)) ([#469](https://github.com/SchweizerischeBundesbahnen/DAS/issues/469)) ([cd84c85](https://github.com/SchweizerischeBundesbahnen/DAS/commit/cd84c854df7dbf001294317e28673b4301a7075b))
-* implement langsamfahrstellen ([#87](https://github.com/SchweizerischeBundesbahnen/DAS/issues/87)) ([#413](https://github.com/SchweizerischeBundesbahnen/DAS/issues/413)) ([4fd494c](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4fd494cc2a3a6d1d58a5c1a0924ac729801ccbe0))
-* implement logging service ([#336](https://github.com/SchweizerischeBundesbahnen/DAS/issues/336)) ([e23c252](https://github.com/SchweizerischeBundesbahnen/DAS/commit/e23c25295b159e25c7729b3ba8dc9274c46bef57))
-* implement protection section ([#407](https://github.com/SchweizerischeBundesbahnen/DAS/issues/407)) ([731b2ad](https://github.com/SchweizerischeBundesbahnen/DAS/commit/731b2ad7b7ccdf66622d411165640a8df4e51559))
-* implement roles in mobile ([#373](https://github.com/SchweizerischeBundesbahnen/DAS/issues/373)) ([a20c5fc](https://github.com/SchweizerischeBundesbahnen/DAS/commit/a20c5fc4b76e2496d037607c8056a75b0e46415b))
-* implement session termination. ([#406](https://github.com/SchweizerischeBundesbahnen/DAS/issues/406)) ([#628](https://github.com/SchweizerischeBundesbahnen/DAS/issues/628)) ([4d0239d](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4d0239d74c8681a8058220c9daf119f12c46eaba))
-* implement train journey search ([#369](https://github.com/SchweizerischeBundesbahnen/DAS/issues/369)) ([adf7fb9](https://github.com/SchweizerischeBundesbahnen/DAS/commit/adf7fb915cec4e55a60dce36ed0c59b5c91c60f1))
-* improve fahrbild with chevron animation, item alignment and bottom spacing ([#94](https://github.com/SchweizerischeBundesbahnen/DAS/issues/94)) ([#570](https://github.com/SchweizerischeBundesbahnen/DAS/issues/570)) ([853ddd2](https://github.com/SchweizerischeBundesbahnen/DAS/commit/853ddd233f3c4a3aaecd7cf4d2be2abc2f6d30fd))
-* iOS Signing and deployment ([#152](https://github.com/SchweizerischeBundesbahnen/DAS/issues/152)) ([141463f](https://github.com/SchweizerischeBundesbahnen/DAS/commit/141463fa90e1adfedd9178c16f0c1e1b6ebeeb63))
-* maneuver mode ([#646](https://github.com/SchweizerischeBundesbahnen/DAS/issues/646)) ([#680](https://github.com/SchweizerischeBundesbahnen/DAS/issues/680)) ([e4122a2](https://github.com/SchweizerischeBundesbahnen/DAS/commit/e4122a202545be307fe720d17fc2e1e38b0bcf3f))
-* sticky header improvement ([#572](https://github.com/SchweizerischeBundesbahnen/DAS/issues/572)) ([#580](https://github.com/SchweizerischeBundesbahnen/DAS/issues/580)) ([9d941dc](https://github.com/SchweizerischeBundesbahnen/DAS/commit/9d941dc4183d304580e994ba526e23123e5c3294))
-* updated koa sound ([dc1bdb6](https://github.com/SchweizerischeBundesbahnen/DAS/commit/dc1bdb6b4fac4343dc4edbded1c9f2d03242a4ee))
-* upgrade to SFERA v3 ([#578](https://github.com/SchweizerischeBundesbahnen/DAS/issues/578)) ([#577](https://github.com/SchweizerischeBundesbahnen/DAS/issues/577)) ([df1d74c](https://github.com/SchweizerischeBundesbahnen/DAS/commit/df1d74c614f8ca16d1abbef9e9a52c55e3a3f689))
-
 
 ### Bug Fixes
 
-* add sound to warnapp ([#708](https://github.com/SchweizerischeBundesbahnen/DAS/issues/708)) ([82d40b3](https://github.com/SchweizerischeBundesbahnen/DAS/commit/82d40b32fa1755199718cbcc1d9951269c1ce3c8))
-* allow to close fahrbild ([#154](https://github.com/SchweizerischeBundesbahnen/DAS/issues/154)) ([8d2e9ae](https://github.com/SchweizerischeBundesbahnen/DAS/commit/8d2e9aec97dd69414e75feac0812221c489bd9df))
-* android bottom padding ([e276798](https://github.com/SchweizerischeBundesbahnen/DAS/commit/e276798edcb920c9b358ee998a46571bfd0f7808))
-* bug of not showing last item in reduced_train_journey fixed ([#738](https://github.com/SchweizerischeBundesbahnen/DAS/issues/738)) ([2fc2f32](https://github.com/SchweizerischeBundesbahnen/DAS/commit/2fc2f323c5a917a17974988324abe69f06f81427))
-* correctly adjust current position to service point ([#676](https://github.com/SchweizerischeBundesbahnen/DAS/issues/676)) ([a3a3c8e](https://github.com/SchweizerischeBundesbahnen/DAS/commit/a3a3c8ec6e5280b13f4ca9dcdf4584655d987f8f))
-* **deps:** update dependency device_info_plus to v11 ([#292](https://github.com/SchweizerischeBundesbahnen/DAS/issues/292)) ([5e08abd](https://github.com/SchweizerischeBundesbahnen/DAS/commit/5e08abdd6382babfbc43d19f7b0d62b04c3b49bf))
-* **deps:** update dependency flutter_bloc to v9 ([#496](https://github.com/SchweizerischeBundesbahnen/DAS/issues/496)) ([1b74d01](https://github.com/SchweizerischeBundesbahnen/DAS/commit/1b74d01697c5401c2cd9f02795eae0948204a9be))
-* **deps:** update dependency get_it to v8 ([#276](https://github.com/SchweizerischeBundesbahnen/DAS/issues/276)) ([a430702](https://github.com/SchweizerischeBundesbahnen/DAS/commit/a4307022565ed94bb43e03d2d6ed19303a5cd6dd))
-* **deps:** update dependency junit:junit to v4.13.2 ([#178](https://github.com/SchweizerischeBundesbahnen/DAS/issues/178)) ([4bc903c](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4bc903c1c3fc914d94395e3188d0cdc12781a79e))
-* do not show BU count on expanded balises ([#532](https://github.com/SchweizerischeBundesbahnen/DAS/issues/532)) ([a5852db](https://github.com/SchweizerischeBundesbahnen/DAS/commit/a5852db88b8b945549fea31bac5643ef8212ccf0))
-* driving mode, mock backend url, message header attributes ([#326](https://github.com/SchweizerischeBundesbahnen/DAS/issues/326)) ([4524d31](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4524d31379c02c13452b9fbfd22e4fb1c3b59cdc))
-* dummy change for new build ([f6b8c44](https://github.com/SchweizerischeBundesbahnen/DAS/commit/f6b8c443bb4fae3c778cd9f0397b482088aee015))
-* fix station speed parsing ([#491](https://github.com/SchweizerischeBundesbahnen/DAS/issues/491)) ([00f9a81](https://github.com/SchweizerischeBundesbahnen/DAS/commit/00f9a816c6d0d20140c02a7f37bf85aeb0846457))
-* fixed the padding in the punctuality display ([#122](https://github.com/SchweizerischeBundesbahnen/DAS/issues/122)) ([#501](https://github.com/SchweizerischeBundesbahnen/DAS/issues/501)) ([17511ff](https://github.com/SchweizerischeBundesbahnen/DAS/commit/17511ffa1cf48472df2d46a31e912349b181006e))
-* footnotes ([4b814d8](https://github.com/SchweizerischeBundesbahnen/DAS/commit/4b814d8093be877c2210bbed9270f32826f3b3a0))
-* ios build error ([0f8390e](https://github.com/SchweizerischeBundesbahnen/DAS/commit/0f8390edf361f2f61cd1b775ad080ed6bbb81980))
-* radn footnotes ([#781](https://github.com/SchweizerischeBundesbahnen/DAS/issues/781)) ([08f444f](https://github.com/SchweizerischeBundesbahnen/DAS/commit/08f444f993e58078f26a9a25104ac88df5746d08))
-* rename stopping location to halt to match newest spec ([#503](https://github.com/SchweizerischeBundesbahnen/DAS/issues/503)) ([b01331d](https://github.com/SchweizerischeBundesbahnen/DAS/commit/b01331d071e03bb7b617207b6f6cf660d5c0ecae))
-* require fullscreen ([0d37832](https://github.com/SchweizerischeBundesbahnen/DAS/commit/0d3783291e63e1d137f27ec7f975d298a633fbf3))
-* update dependency to fix android login problem ([2aa4bc0](https://github.com/SchweizerischeBundesbahnen/DAS/commit/2aa4bc054876905d0da7d55b77ebbf0540a52ff8))
-* use nsp value for bracket station text ([#508](https://github.com/SchweizerischeBundesbahnen/DAS/issues/508)) ([#509](https://github.com/SchweizerischeBundesbahnen/DAS/issues/509)) ([04d1034](https://github.com/SchweizerischeBundesbahnen/DAS/commit/04d1034105fde62dc9c7ed66f920f4946cc500a9))
-* ux requested changes ([#725](https://github.com/SchweizerischeBundesbahnen/DAS/issues/725)) ([8b494fd](https://github.com/SchweizerischeBundesbahnen/DAS/commit/8b494fda5626dda83a020d1b613f66aa84c63818))
+* empty release for CI purposes
 
 ## [0.14.2](https://github.com/SchweizerischeBundesbahnen/DAS/compare/das_client-v0.14.1...das_client-v0.14.2) (2025-04-02)
 


### PR DESCRIPTION

release please has twice created wrong changelogs

- 0.15.0 release
- 0.19.0 release

this PR fixes the changelog

and yes, the 0.15.0 release was empty. look at diff :eyes: