### PR TITLE
feat: client handles xx speeds (#502)

### DIFF
--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/graduated_speeds_cell_body.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/graduated_speeds_cell_body.dart
@@ -74,7 +74,7 @@ class GraduatedSpeedsCellBody extends StatelessWidget {
                 )
               : null,
           child: Text(
-            speed.speed.toString(),
+            speed.speed,
             style: DASTableTheme.of(context)?.data.dataTextStyle?.copyWith(height: 0),
           ),
         );
@@ -86,7 +86,7 @@ class GraduatedSpeedsCellBody extends StatelessWidget {
 // extensions
 
 extension _SpeedIterableX on Iterable<Speed> {
-  String toJoinedString({String divider = '-'}) => map((it) => it.speed.toString()).join(divider);
+  String toJoinedString({String divider = '-'}) => map((it) => it.speed).join(divider);
 
   bool get hasSquaredOrCircled => any((it) => it.isSquared || it.isCircled);
 }

--- a/das_client/sfera/lib/src/model/journey/speed.dart
+++ b/das_client/sfera/lib/src/model/journey/speed.dart
@@ -11,9 +11,9 @@ class Speed {
 
   factory Speed.from(String value) {
     if (RegExp(speedRegex).hasMatch(value)) {
-      final digit = RegExp(r'\d+').stringMatch(value);
+      final speedValue = RegExp(r'\d+|XX').stringMatch(value);
       return Speed(
-        speed: int.parse(digit!),
+        speed: speedValue!,
         isCircled: value.contains('{'),
         isSquared: value.contains('['),
       );
@@ -22,9 +22,10 @@ class Speed {
     throw ArgumentError('Invalid speed format: $value');
   }
 
-  static const speedRegex = r'^\d+$|^\[\d+\]$|^\{\d+\}$'; // exp. 50, {60} or [70]
+  // Accepts 50, {60}, [70], XX, {XX}, [XX]
+  static const speedRegex = r'^(\d+|XX)$|^\[(\d+|XX)\]$|^\{(\d+|XX)\}$';
 
-  final int speed;
+  final String speed;
 
   /// Normally means that speed is higher than given by signaling. Can have other meanings so this variable is named generically.
   final bool isSquared;

--- a/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
+++ b/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
@@ -924,7 +924,7 @@ void main() {
     // check ServicePoint Burgdorf
 
     final graduatedStationSpeeds2 = servicePoints[2].localSpeedData!.speeds;
-    expect(graduatedStationSpeeds2, hasLength(6));
+    expect(graduatedStationSpeeds2, hasLength(7));
 
     final rSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.R);
     expect(rSpeedEntry2, isNotNull);
@@ -961,6 +961,15 @@ void main() {
     expect(dSpeedEntry2.incomingSpeeds, hasLength(1));
     _checkSpeed(dSpeedEntry2.incomingSpeeds[0], '70');
     expect(dSpeedEntry2.outgoingSpeeds, isEmpty);
+
+    final nSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.N);
+    expect(nSpeedEntry2, isNotNull);
+    expect(nSpeedEntry2!.text, isNull);
+    expect(nSpeedEntry2.trainSeries, TrainSeries.N);
+    expect(nSpeedEntry2.incomingSpeeds, hasLength(2));
+    _checkSpeed(nSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(nSpeedEntry2.incomingSpeeds[1], 'XX', isCircled: true);
+    _checkSpeed(nSpeedEntry2.outgoingSpeeds[0], 'XX', isSquared: true);
 
     // check ServicePoint Olten
 
@@ -1054,7 +1063,7 @@ void main() {
     // check ServicePoint Burgdorf
 
     final graduatedStationSpeeds2 = servicePoints[2].graduatedSpeedInfo!.speeds;
-    expect(graduatedStationSpeeds2, hasLength(4));
+    expect(graduatedStationSpeeds2, hasLength(5));
 
     final rSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.R);
     expect(rSpeedEntry2, isNotNull);
@@ -1091,6 +1100,15 @@ void main() {
     expect(dSpeedEntry2.incomingSpeeds, hasLength(1));
     _checkSpeed(dSpeedEntry2.incomingSpeeds[0], '70');
     expect(dSpeedEntry2.outgoingSpeeds, isEmpty);
+
+    final nSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.N);
+    expect(nSpeedEntry2, isNotNull);
+    expect(nSpeedEntry2!.text, 'Zusatzinformation C');
+    expect(nSpeedEntry2.trainSeries, TrainSeries.N);
+    expect(nSpeedEntry2.incomingSpeeds, hasLength(2));
+    _checkSpeed(nSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(nSpeedEntry2.incomingSpeeds[1], 'XX', isCircled: true);
+    _checkSpeed(nSpeedEntry2.outgoingSpeeds[0], 'XX', isSquared: true);
 
     // check ServicePoint Olten
 

--- a/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
+++ b/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
@@ -286,11 +286,11 @@ void main() {
     expect(endSignaling, hasLength(2));
     expect(endSignaling[0].speedData, isNotNull);
     expect(endSignaling[0].speedData!.speeds[0].trainSeries, TrainSeries.R);
-    expect(endSignaling[0].speedData!.speeds[0].incomingSpeeds[0].speed, 55);
+    expect(endSignaling[0].speedData!.speeds[0].incomingSpeeds[0].speed, '55');
     expect(endSignaling[0].speedData!.speeds[0].breakSeries, 115);
     expect(endSignaling[1].speedData, isNotNull);
     expect(endSignaling[1].speedData!.speeds[0].trainSeries, TrainSeries.R);
-    expect(endSignaling[1].speedData!.speeds[0].incomingSpeeds[0].speed, 80);
+    expect(endSignaling[1].speedData!.speeds[0].incomingSpeeds[0].speed, '80');
     expect(endSignaling[1].speedData!.speeds[0].breakSeries, 115);
   });
 
@@ -630,21 +630,21 @@ void main() {
     expect(speedChanges[0].text, 'Zahnstangen Anfang');
     expect(speedChanges[0].speedData!.speeds, hasLength(2));
     expect(speedChanges[0].speedData!.speeds[0].trainSeries, TrainSeries.R);
-    expect(speedChanges[0].speedData!.speeds[0].incomingSpeeds[0].speed, 55);
+    expect(speedChanges[0].speedData!.speeds[0].incomingSpeeds[0].speed, '55');
     expect(speedChanges[0].speedData!.speeds[0].reduced, true);
     expect(speedChanges[0].speedData!.speeds[0].breakSeries, 100);
     expect(speedChanges[0].speedData!.speeds[1].trainSeries, TrainSeries.A);
-    expect(speedChanges[0].speedData!.speeds[1].incomingSpeeds[0].speed, 50);
+    expect(speedChanges[0].speedData!.speeds[1].incomingSpeeds[0].speed, '50');
     expect(speedChanges[0].speedData!.speeds[1].reduced, false);
     expect(speedChanges[0].speedData!.speeds[1].breakSeries, 30);
     expect(speedChanges[1].text, 'Zahnstangen Ende');
     expect(speedChanges[1].speedData!.speeds, hasLength(2));
     expect(speedChanges[1].speedData!.speeds[0].trainSeries, TrainSeries.R);
-    expect(speedChanges[1].speedData!.speeds[0].incomingSpeeds[0].speed, 80);
+    expect(speedChanges[1].speedData!.speeds[0].incomingSpeeds[0].speed, '80');
     expect(speedChanges[1].speedData!.speeds[0].reduced, false);
     expect(speedChanges[1].speedData!.speeds[0].breakSeries, 100);
     expect(speedChanges[1].speedData!.speeds[1].trainSeries, TrainSeries.A);
-    expect(speedChanges[1].speedData!.speeds[1].incomingSpeeds[0].speed, 80);
+    expect(speedChanges[1].speedData!.speeds[1].incomingSpeeds[0].speed, '80');
     expect(speedChanges[1].speedData!.speeds[1].reduced, false);
     expect(speedChanges[1].speedData!.speeds[1].breakSeries, 30);
   });
@@ -666,11 +666,11 @@ void main() {
     expect(connectionTracks[2].speedData, isNotNull);
     expect(connectionTracks[2].speedData!.speeds, hasLength(2));
     expect(connectionTracks[2].speedData!.speeds[0].trainSeries, TrainSeries.R);
-    expect(connectionTracks[2].speedData!.speeds[0].incomingSpeeds[0].speed, 45);
+    expect(connectionTracks[2].speedData!.speeds[0].incomingSpeeds[0].speed, '45');
     expect(connectionTracks[2].speedData!.speeds[0].reduced, false);
     expect(connectionTracks[2].speedData!.speeds[0].breakSeries, isNull);
     expect(connectionTracks[2].speedData!.speeds[1].trainSeries, TrainSeries.A);
-    expect(connectionTracks[2].speedData!.speeds[1].incomingSpeeds[0].speed, 40);
+    expect(connectionTracks[2].speedData!.speeds[1].incomingSpeeds[0].speed, '40');
     expect(connectionTracks[2].speedData!.speeds[1].reduced, false);
     expect(connectionTracks[2].speedData!.speeds[1].breakSeries, isNull);
   });
@@ -688,13 +688,15 @@ void main() {
 
     journey = getJourney('T5', 1);
     expect(journey.valid, true);
-    expect(journey.metadata.availableBreakSeries, hasLength(16));
+    expect(journey.metadata.availableBreakSeries, hasLength(17));
     expect(journey.metadata.availableBreakSeries.elementAt(0).trainSeries, TrainSeries.R);
     expect(journey.metadata.availableBreakSeries.elementAt(0).breakSeries, 105);
     expect(journey.metadata.availableBreakSeries.elementAt(5).trainSeries, TrainSeries.A);
     expect(journey.metadata.availableBreakSeries.elementAt(5).breakSeries, 50);
     expect(journey.metadata.availableBreakSeries.elementAt(15).trainSeries, TrainSeries.D);
     expect(journey.metadata.availableBreakSeries.elementAt(15).breakSeries, 30);
+    expect(journey.metadata.availableBreakSeries.elementAt(16).trainSeries, TrainSeries.N);
+    expect(journey.metadata.availableBreakSeries.elementAt(16).breakSeries, 30);
 
     journey = getJourney('T8', 1);
     expect(journey.valid, true);
@@ -714,19 +716,19 @@ void main() {
     final curvePoints = journey.data.where((it) => it.type == Datatype.curvePoint).cast<CurvePoint>().toList();
     expect(curvePoints, hasLength(3));
     expect(curvePoints[0].localSpeedData, isNotNull);
-    expect(curvePoints[0].localSpeedData!.speeds, hasLength(3));
+    expect(curvePoints[0].localSpeedData!.speeds, hasLength(4));
     expect(curvePoints[1].localSpeedData, isNotNull);
-    expect(curvePoints[1].localSpeedData!.speeds, hasLength(2));
+    expect(curvePoints[1].localSpeedData!.speeds, hasLength(3));
     expect(curvePoints[2].localSpeedData, isNull);
 
     final servicePoints = journey.data.where((it) => it.type == Datatype.servicePoint).cast<ServicePoint>().toList();
     expect(servicePoints, hasLength(3));
     expect(servicePoints[0].speedData, isNotNull);
-    expect(servicePoints[0].speedData!.speeds, hasLength(16));
+    expect(servicePoints[0].speedData!.speeds, hasLength(17));
     expect(servicePoints[1].speedData, isNotNull);
-    expect(servicePoints[1].speedData!.speeds, hasLength(6));
+    expect(servicePoints[1].speedData!.speeds, hasLength(7));
     expect(servicePoints[2].speedData, isNotNull);
-    expect(servicePoints[2].speedData!.speeds, hasLength(16));
+    expect(servicePoints[2].speedData!.speeds, hasLength(17));
   });
 
   test('Test train characteristics break series is parsed correctly', () async {
@@ -881,9 +883,9 @@ void main() {
     expect(rSpeedEntry1!.text, isNull);
     expect(rSpeedEntry1.trainSeries, TrainSeries.R);
     expect(rSpeedEntry1.incomingSpeeds, hasLength(3));
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[0], 75);
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[1], 70);
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[2], 60);
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[0], '75');
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[1], '70');
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[2], '60');
     expect(rSpeedEntry1.outgoingSpeeds, isEmpty);
 
     final oSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.O);
@@ -891,9 +893,9 @@ void main() {
     expect(oSpeedEntry1!.text, isNull);
     expect(oSpeedEntry1.trainSeries, TrainSeries.O);
     expect(oSpeedEntry1.incomingSpeeds, hasLength(3));
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[0], 75);
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[1], 70);
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[2], 60);
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[0], '75');
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[1], '70');
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[2], '60');
     expect(oSpeedEntry1.outgoingSpeeds, isEmpty);
 
     final sSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.S);
@@ -901,19 +903,19 @@ void main() {
     expect(sSpeedEntry1!.text, isNull);
     expect(sSpeedEntry1.trainSeries, TrainSeries.S);
     expect(sSpeedEntry1.incomingSpeeds, hasLength(2));
-    _checkSpeed(sSpeedEntry1.incomingSpeeds[0], 70);
-    _checkSpeed(sSpeedEntry1.incomingSpeeds[1], 60);
+    _checkSpeed(sSpeedEntry1.incomingSpeeds[0], '70');
+    _checkSpeed(sSpeedEntry1.incomingSpeeds[1], '60');
     expect(sSpeedEntry1.outgoingSpeeds, hasLength(1));
-    _checkSpeed(sSpeedEntry1.outgoingSpeeds[0], 50);
+    _checkSpeed(sSpeedEntry1.outgoingSpeeds[0], '50');
 
     final nSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.N);
     expect(nSpeedEntry1, isNotNull);
     expect(nSpeedEntry1!.text, isNull);
     expect(nSpeedEntry1.trainSeries, TrainSeries.N);
     expect(nSpeedEntry1.incomingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry1.incomingSpeeds[0], 70);
+    _checkSpeed(nSpeedEntry1.incomingSpeeds[0], '70');
     expect(nSpeedEntry1.outgoingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry1.outgoingSpeeds[0], 60);
+    _checkSpeed(nSpeedEntry1.outgoingSpeeds[0], '60');
 
     // check ServicePoint Wankdorf
 
@@ -929,27 +931,27 @@ void main() {
     expect(rSpeedEntry2!.text, isNull);
     expect(rSpeedEntry2.trainSeries, TrainSeries.R);
     expect(rSpeedEntry2.incomingSpeeds, hasLength(2));
-    _checkSpeed(rSpeedEntry2.incomingSpeeds[0], 75);
-    _checkSpeed(rSpeedEntry2.incomingSpeeds[1], 70, isCircled: true);
+    _checkSpeed(rSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(rSpeedEntry2.incomingSpeeds[1], '70', isCircled: true);
     expect(rSpeedEntry2.outgoingSpeeds, hasLength(1));
-    _checkSpeed(rSpeedEntry2.outgoingSpeeds[0], 60, isSquared: true);
+    _checkSpeed(rSpeedEntry2.outgoingSpeeds[0], '60', isSquared: true);
 
     final oSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.O);
     expect(oSpeedEntry2, isNotNull);
     expect(oSpeedEntry2!.text, isNull);
     expect(oSpeedEntry2.trainSeries, TrainSeries.O);
     expect(oSpeedEntry2.incomingSpeeds, hasLength(2));
-    _checkSpeed(oSpeedEntry2.incomingSpeeds[0], 75);
-    _checkSpeed(oSpeedEntry2.incomingSpeeds[1], 70, isCircled: true);
+    _checkSpeed(oSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(oSpeedEntry2.incomingSpeeds[1], '70', isCircled: true);
     expect(oSpeedEntry2.outgoingSpeeds, hasLength(1));
-    _checkSpeed(oSpeedEntry2.outgoingSpeeds[0], 60, isSquared: true);
+    _checkSpeed(oSpeedEntry2.outgoingSpeeds[0], '60', isSquared: true);
 
     final aSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.A);
     expect(aSpeedEntry2, isNotNull);
     expect(aSpeedEntry2!.text, isNull);
     expect(aSpeedEntry2.trainSeries, TrainSeries.A);
     expect(aSpeedEntry2.incomingSpeeds, hasLength(1));
-    _checkSpeed(aSpeedEntry2.incomingSpeeds[0], 70);
+    _checkSpeed(aSpeedEntry2.incomingSpeeds[0], '70');
     expect(aSpeedEntry2.outgoingSpeeds, isEmpty);
 
     final dSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.D);
@@ -957,7 +959,7 @@ void main() {
     expect(dSpeedEntry2!.text, isNull);
     expect(dSpeedEntry2.trainSeries, TrainSeries.D);
     expect(dSpeedEntry2.incomingSpeeds, hasLength(1));
-    _checkSpeed(dSpeedEntry2.incomingSpeeds[0], 70);
+    _checkSpeed(dSpeedEntry2.incomingSpeeds[0], '70');
     expect(dSpeedEntry2.outgoingSpeeds, isEmpty);
 
     // check ServicePoint Olten
@@ -970,20 +972,20 @@ void main() {
     expect(nSpeedEntry3!.text, isNull);
     expect(nSpeedEntry3.trainSeries, TrainSeries.N);
     expect(nSpeedEntry3.incomingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry3.incomingSpeeds[0], 80);
+    _checkSpeed(nSpeedEntry3.incomingSpeeds[0], '80');
     expect(nSpeedEntry3.outgoingSpeeds, hasLength(2));
-    _checkSpeed(nSpeedEntry3.outgoingSpeeds[0], 70);
-    _checkSpeed(nSpeedEntry3.outgoingSpeeds[1], 60);
+    _checkSpeed(nSpeedEntry3.outgoingSpeeds[0], '70');
+    _checkSpeed(nSpeedEntry3.outgoingSpeeds[1], '60');
 
     final sSpeedEntry3 = graduatedStationSpeeds3.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.S);
     expect(sSpeedEntry3, isNotNull);
     expect(sSpeedEntry3!.text, isNull);
     expect(sSpeedEntry3.trainSeries, TrainSeries.S);
     expect(sSpeedEntry3.incomingSpeeds, hasLength(2));
-    _checkSpeed(sSpeedEntry3.incomingSpeeds[0], 70);
-    _checkSpeed(sSpeedEntry3.incomingSpeeds[1], 60);
+    _checkSpeed(sSpeedEntry3.incomingSpeeds[0], '70');
+    _checkSpeed(sSpeedEntry3.incomingSpeeds[1], '60');
     expect(sSpeedEntry3.outgoingSpeeds, hasLength(1));
-    _checkSpeed(sSpeedEntry3.outgoingSpeeds[0], 50);
+    _checkSpeed(sSpeedEntry3.outgoingSpeeds[0], '50');
   });
 
   test('Test graduated station speeds are parsed correctly', () async {
@@ -1004,9 +1006,9 @@ void main() {
     expect(rSpeedEntry1!.text, 'Zusatzinformation A');
     expect(rSpeedEntry1.trainSeries, TrainSeries.R);
     expect(rSpeedEntry1.incomingSpeeds, hasLength(3));
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[0], 75);
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[1], 70);
-    _checkSpeed(rSpeedEntry1.incomingSpeeds[2], 60);
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[0], '75');
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[1], '70');
+    _checkSpeed(rSpeedEntry1.incomingSpeeds[2], '60');
     expect(rSpeedEntry1.outgoingSpeeds, isEmpty);
 
     final oSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.O);
@@ -1014,9 +1016,9 @@ void main() {
     expect(oSpeedEntry1!.text, 'Zusatzinformation A');
     expect(oSpeedEntry1.trainSeries, TrainSeries.O);
     expect(oSpeedEntry1.incomingSpeeds, hasLength(3));
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[0], 75);
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[1], 70);
-    _checkSpeed(oSpeedEntry1.incomingSpeeds[2], 60);
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[0], '75');
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[1], '70');
+    _checkSpeed(oSpeedEntry1.incomingSpeeds[2], '60');
     expect(oSpeedEntry1.outgoingSpeeds, isEmpty);
 
     final sSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.S);
@@ -1024,19 +1026,19 @@ void main() {
     expect(sSpeedEntry1!.text, 'Zusatzinformation A');
     expect(sSpeedEntry1.trainSeries, TrainSeries.S);
     expect(sSpeedEntry1.incomingSpeeds, hasLength(2));
-    _checkSpeed(sSpeedEntry1.incomingSpeeds[0], 70);
-    _checkSpeed(sSpeedEntry1.incomingSpeeds[1], 60);
+    _checkSpeed(sSpeedEntry1.incomingSpeeds[0], '70');
+    _checkSpeed(sSpeedEntry1.incomingSpeeds[1], '60');
     expect(sSpeedEntry1.outgoingSpeeds, hasLength(1));
-    _checkSpeed(sSpeedEntry1.outgoingSpeeds[0], 50);
+    _checkSpeed(sSpeedEntry1.outgoingSpeeds[0], '50');
 
     final nSpeedEntry1 = graduatedStationSpeeds1.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.N);
     expect(nSpeedEntry1, isNotNull);
     expect(nSpeedEntry1!.text, 'Zusatzinformation B');
     expect(nSpeedEntry1.trainSeries, TrainSeries.N);
     expect(nSpeedEntry1.incomingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry1.incomingSpeeds[0], 70);
+    _checkSpeed(nSpeedEntry1.incomingSpeeds[0], '70');
     expect(nSpeedEntry1.outgoingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry1.outgoingSpeeds[0], 60);
+    _checkSpeed(nSpeedEntry1.outgoingSpeeds[0], '60');
 
     final relevantSpeedInfo = servicePoints[0].relevantGraduatedSpeedInfo(
       BreakSeries(trainSeries: TrainSeries.N, breakSeries: 50),
@@ -1059,27 +1061,27 @@ void main() {
     expect(rSpeedEntry2!.text, 'Zusatzinformation A');
     expect(rSpeedEntry2.trainSeries, TrainSeries.R);
     expect(rSpeedEntry2.incomingSpeeds, hasLength(2));
-    _checkSpeed(rSpeedEntry2.incomingSpeeds[0], 75);
-    _checkSpeed(rSpeedEntry2.incomingSpeeds[1], 70, isCircled: true);
+    _checkSpeed(rSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(rSpeedEntry2.incomingSpeeds[1], '70', isCircled: true);
     expect(rSpeedEntry2.outgoingSpeeds, hasLength(1));
-    _checkSpeed(rSpeedEntry2.outgoingSpeeds[0], 60, isSquared: true);
+    _checkSpeed(rSpeedEntry2.outgoingSpeeds[0], '60', isSquared: true);
 
     final oSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.O);
     expect(oSpeedEntry2, isNotNull);
     expect(oSpeedEntry2!.text, 'Zusatzinformation A');
     expect(oSpeedEntry2.trainSeries, TrainSeries.O);
     expect(oSpeedEntry2.incomingSpeeds, hasLength(2));
-    _checkSpeed(oSpeedEntry2.incomingSpeeds[0], 75);
-    _checkSpeed(oSpeedEntry2.incomingSpeeds[1], 70, isCircled: true);
+    _checkSpeed(oSpeedEntry2.incomingSpeeds[0], '75');
+    _checkSpeed(oSpeedEntry2.incomingSpeeds[1], '70', isCircled: true);
     expect(oSpeedEntry2.outgoingSpeeds, hasLength(1));
-    _checkSpeed(oSpeedEntry2.outgoingSpeeds[0], 60, isSquared: true);
+    _checkSpeed(oSpeedEntry2.outgoingSpeeds[0], '60', isSquared: true);
 
     final aSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.A);
     expect(aSpeedEntry2, isNotNull);
     expect(aSpeedEntry2!.text, 'Zusatzinformation B');
     expect(aSpeedEntry2.trainSeries, TrainSeries.A);
     expect(aSpeedEntry2.incomingSpeeds, hasLength(1));
-    _checkSpeed(aSpeedEntry2.incomingSpeeds[0], 70);
+    _checkSpeed(aSpeedEntry2.incomingSpeeds[0], '70');
     expect(aSpeedEntry2.outgoingSpeeds, isEmpty);
 
     final dSpeedEntry2 = graduatedStationSpeeds2.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.D);
@@ -1087,7 +1089,7 @@ void main() {
     expect(dSpeedEntry2!.text, 'Zusatzinformation B');
     expect(dSpeedEntry2.trainSeries, TrainSeries.D);
     expect(dSpeedEntry2.incomingSpeeds, hasLength(1));
-    _checkSpeed(dSpeedEntry2.incomingSpeeds[0], 70);
+    _checkSpeed(dSpeedEntry2.incomingSpeeds[0], '70');
     expect(dSpeedEntry2.outgoingSpeeds, isEmpty);
 
     // check ServicePoint Olten
@@ -1100,20 +1102,20 @@ void main() {
     expect(nSpeedEntry3!.text, 'Zusatzinformation A');
     expect(nSpeedEntry3.trainSeries, TrainSeries.N);
     expect(nSpeedEntry3.incomingSpeeds, hasLength(1));
-    _checkSpeed(nSpeedEntry3.incomingSpeeds[0], 80);
+    _checkSpeed(nSpeedEntry3.incomingSpeeds[0], '80');
     expect(nSpeedEntry3.outgoingSpeeds, hasLength(2));
-    _checkSpeed(nSpeedEntry3.outgoingSpeeds[0], 70);
-    _checkSpeed(nSpeedEntry3.outgoingSpeeds[1], 60);
+    _checkSpeed(nSpeedEntry3.outgoingSpeeds[0], '70');
+    _checkSpeed(nSpeedEntry3.outgoingSpeeds[1], '60');
 
     final sSpeedEntry3 = graduatedStationSpeeds3.firstWhereOrNull((speeds) => speeds.trainSeries == TrainSeries.S);
     expect(sSpeedEntry3, isNotNull);
     expect(sSpeedEntry3!.text, 'Zusatzinformation A');
     expect(sSpeedEntry3.trainSeries, TrainSeries.S);
     expect(sSpeedEntry3.incomingSpeeds, hasLength(2));
-    _checkSpeed(sSpeedEntry3.incomingSpeeds[0], 70);
-    _checkSpeed(sSpeedEntry3.incomingSpeeds[1], 60);
+    _checkSpeed(sSpeedEntry3.incomingSpeeds[0], '70');
+    _checkSpeed(sSpeedEntry3.incomingSpeeds[1], '60');
     expect(sSpeedEntry3.outgoingSpeeds, hasLength(1));
-    _checkSpeed(sSpeedEntry3.outgoingSpeeds[0], 50);
+    _checkSpeed(sSpeedEntry3.outgoingSpeeds[0], '50');
   });
 
   test('Test current position is start when nothing is given ', () async {
@@ -1428,7 +1430,7 @@ void main() {
   });
 }
 
-void _checkSpeed(Speed speed, int speedValue, {bool isCircled = false, bool isSquared = false}) {
+void _checkSpeed(Speed speed, String speedValue, {bool isCircled = false, bool isSquared = false}) {
   expect(speed.speed, speedValue);
   expect(speed.isCircled, isCircled);
   expect(speed.isSquared, isSquared);

--- a/das_client/sfera/test/src/model/journey/graduated_speeds_test.dart
+++ b/das_client/sfera/test/src/model/journey/graduated_speeds_test.dart
@@ -13,20 +13,31 @@ void main() {
 
     // THEN
     expect(speed1.incomingSpeeds, hasLength(1));
-    checkSpeed(speed1.incomingSpeeds[0], 100);
+    checkSpeed(speed1.incomingSpeeds[0], '100');
     expect(speed1.outgoingSpeeds, isEmpty);
 
     expect(speed2.incomingSpeeds, hasLength(2));
-    checkSpeed(speed2.incomingSpeeds[0], 100);
-    checkSpeed(speed2.incomingSpeeds[1], 90);
+    checkSpeed(speed2.incomingSpeeds[0], '100');
+    checkSpeed(speed2.incomingSpeeds[1], '90');
     expect(speed2.outgoingSpeeds, isEmpty);
 
     expect(speed3.incomingSpeeds, hasLength(3));
-    checkSpeed(speed3.incomingSpeeds[0], 100);
-    checkSpeed(speed3.incomingSpeeds[1], 90);
-    checkSpeed(speed3.incomingSpeeds[2], 80);
+    checkSpeed(speed3.incomingSpeeds[0], '100');
+    checkSpeed(speed3.incomingSpeeds[1], '90');
+    checkSpeed(speed3.incomingSpeeds[2], '80');
     expect(speed3.outgoingSpeeds, isEmpty);
   });
+
+  test('test with XX speeds', () {
+    // GIVEN WHEN
+    final speed1 = Speeds.from(TrainSeries.R, 'XX');
+
+    // THEN
+    expect(speed1.incomingSpeeds, hasLength(1));
+    checkSpeed(speed1.incomingSpeeds[0], 'XX');
+    expect(speed1.outgoingSpeeds, isEmpty);
+  });
+
   test('test with incoming and outgoing station speeds', () {
     // GIVEN WHEN
     final speed1 = Speeds.from(TrainSeries.R, '100/70');
@@ -41,67 +52,67 @@ void main() {
 
     // THEN
     expect(speed1.incomingSpeeds, hasLength(1));
-    checkSpeed(speed1.incomingSpeeds[0], 100);
+    checkSpeed(speed1.incomingSpeeds[0], '100');
     expect(speed1.outgoingSpeeds, hasLength(1));
-    checkSpeed(speed1.outgoingSpeeds[0], 70);
+    checkSpeed(speed1.outgoingSpeeds[0], '70');
 
     expect(speed2.incomingSpeeds, hasLength(2));
-    checkSpeed(speed2.incomingSpeeds[0], 100);
-    checkSpeed(speed2.incomingSpeeds[1], 90);
+    checkSpeed(speed2.incomingSpeeds[0], '100');
+    checkSpeed(speed2.incomingSpeeds[1], '90');
     expect(speed2.outgoingSpeeds, hasLength(1));
-    checkSpeed(speed2.outgoingSpeeds[0], 70);
+    checkSpeed(speed2.outgoingSpeeds[0], '70');
 
     expect(speed3.incomingSpeeds, hasLength(3));
-    checkSpeed(speed3.incomingSpeeds[0], 100);
-    checkSpeed(speed3.incomingSpeeds[1], 90);
-    checkSpeed(speed3.incomingSpeeds[2], 80);
+    checkSpeed(speed3.incomingSpeeds[0], '100');
+    checkSpeed(speed3.incomingSpeeds[1], '90');
+    checkSpeed(speed3.incomingSpeeds[2], '80');
     expect(speed3.outgoingSpeeds, hasLength(1));
-    checkSpeed(speed3.outgoingSpeeds[0], 70);
+    checkSpeed(speed3.outgoingSpeeds[0], '70');
 
     expect(speed4.incomingSpeeds, hasLength(1));
-    checkSpeed(speed4.incomingSpeeds[0], 100);
+    checkSpeed(speed4.incomingSpeeds[0], '100');
     expect(speed4.outgoingSpeeds, hasLength(2));
-    checkSpeed(speed4.outgoingSpeeds[0], 70);
-    checkSpeed(speed4.outgoingSpeeds[1], 60);
+    checkSpeed(speed4.outgoingSpeeds[0], '70');
+    checkSpeed(speed4.outgoingSpeeds[1], '60');
 
     expect(speed5.incomingSpeeds, hasLength(2));
-    checkSpeed(speed5.incomingSpeeds[0], 100);
-    checkSpeed(speed5.incomingSpeeds[1], 90);
+    checkSpeed(speed5.incomingSpeeds[0], '100');
+    checkSpeed(speed5.incomingSpeeds[1], '90');
     expect(speed5.outgoingSpeeds, hasLength(2));
-    checkSpeed(speed5.outgoingSpeeds[0], 70);
-    checkSpeed(speed5.outgoingSpeeds[1], 60);
+    checkSpeed(speed5.outgoingSpeeds[0], '70');
+    checkSpeed(speed5.outgoingSpeeds[1], '60');
 
     expect(speed6.incomingSpeeds, hasLength(3));
-    checkSpeed(speed6.incomingSpeeds[0], 100);
-    checkSpeed(speed6.incomingSpeeds[1], 90);
-    checkSpeed(speed6.incomingSpeeds[2], 80);
+    checkSpeed(speed6.incomingSpeeds[0], '100');
+    checkSpeed(speed6.incomingSpeeds[1], '90');
+    checkSpeed(speed6.incomingSpeeds[2], '80');
     expect(speed6.outgoingSpeeds, hasLength(2));
-    checkSpeed(speed6.outgoingSpeeds[0], 70);
-    checkSpeed(speed6.outgoingSpeeds[1], 60);
+    checkSpeed(speed6.outgoingSpeeds[0], '70');
+    checkSpeed(speed6.outgoingSpeeds[1], '60');
 
     expect(speed7.incomingSpeeds, hasLength(1));
-    checkSpeed(speed7.incomingSpeeds[0], 100);
+    checkSpeed(speed7.incomingSpeeds[0], '100');
     expect(speed7.outgoingSpeeds, hasLength(3));
-    checkSpeed(speed7.outgoingSpeeds[0], 70);
-    checkSpeed(speed7.outgoingSpeeds[1], 60);
-    checkSpeed(speed7.outgoingSpeeds[2], 50);
+    checkSpeed(speed7.outgoingSpeeds[0], '70');
+    checkSpeed(speed7.outgoingSpeeds[1], '60');
+    checkSpeed(speed7.outgoingSpeeds[2], '50');
 
     expect(speed8.incomingSpeeds, hasLength(2));
-    checkSpeed(speed8.incomingSpeeds[0], 100);
-    checkSpeed(speed8.incomingSpeeds[1], 90);
+    checkSpeed(speed8.incomingSpeeds[0], '100');
+    checkSpeed(speed8.incomingSpeeds[1], '90');
     expect(speed8.outgoingSpeeds, hasLength(3));
-    checkSpeed(speed8.outgoingSpeeds[0], 70);
-    checkSpeed(speed8.outgoingSpeeds[1], 60);
-    checkSpeed(speed8.outgoingSpeeds[2], 50);
+    checkSpeed(speed8.outgoingSpeeds[0], '70');
+    checkSpeed(speed8.outgoingSpeeds[1], '60');
+    checkSpeed(speed8.outgoingSpeeds[2], '50');
 
     expect(speed9.incomingSpeeds, hasLength(3));
-    checkSpeed(speed9.incomingSpeeds[0], 100);
-    checkSpeed(speed9.incomingSpeeds[1], 90);
-    checkSpeed(speed9.incomingSpeeds[2], 80);
+    checkSpeed(speed9.incomingSpeeds[0], '100');
+    checkSpeed(speed9.incomingSpeeds[1], '90');
+    checkSpeed(speed9.incomingSpeeds[2], '80');
     expect(speed9.outgoingSpeeds, hasLength(3));
-    checkSpeed(speed9.outgoingSpeeds[0], 70);
-    checkSpeed(speed9.outgoingSpeeds[1], 60);
-    checkSpeed(speed9.outgoingSpeeds[2], 50);
+    checkSpeed(speed9.outgoingSpeeds[0], '70');
+    checkSpeed(speed9.outgoingSpeeds[1], '60');
+    checkSpeed(speed9.outgoingSpeeds[2], '50');
   });
   test('test station speeds with circled or squared values', () {
     // GIVEN WHEN
@@ -111,23 +122,23 @@ void main() {
 
     // THEN
     expect(speed1.incomingSpeeds, hasLength(2));
-    checkSpeed(speed1.incomingSpeeds[0], 100);
-    checkSpeed(speed1.incomingSpeeds[1], 90, isCircled: true);
+    checkSpeed(speed1.incomingSpeeds[0], '100');
+    checkSpeed(speed1.incomingSpeeds[1], '90', isCircled: true);
     expect(speed1.outgoingSpeeds, hasLength(1));
-    checkSpeed(speed1.outgoingSpeeds[0], 70);
+    checkSpeed(speed1.outgoingSpeeds[0], '70');
 
     expect(speed2.incomingSpeeds, hasLength(1));
-    checkSpeed(speed2.incomingSpeeds[0], 100);
+    checkSpeed(speed2.incomingSpeeds[0], '100');
     expect(speed2.outgoingSpeeds, hasLength(2));
-    checkSpeed(speed2.outgoingSpeeds[0], 70);
-    checkSpeed(speed2.outgoingSpeeds[1], 60, isSquared: true);
+    checkSpeed(speed2.outgoingSpeeds[0], '70');
+    checkSpeed(speed2.outgoingSpeeds[1], '60', isSquared: true);
 
     expect(speed3.incomingSpeeds, hasLength(2));
-    checkSpeed(speed3.incomingSpeeds[0], 100, isSquared: true);
-    checkSpeed(speed3.incomingSpeeds[1], 90);
+    checkSpeed(speed3.incomingSpeeds[0], '100', isSquared: true);
+    checkSpeed(speed3.incomingSpeeds[1], '90');
     expect(speed3.outgoingSpeeds, hasLength(2));
-    checkSpeed(speed3.outgoingSpeeds[0], 70, isCircled: true);
-    checkSpeed(speed3.outgoingSpeeds[1], 60, isSquared: true);
+    checkSpeed(speed3.outgoingSpeeds[0], '70', isCircled: true);
+    checkSpeed(speed3.outgoingSpeeds[1], '60', isSquared: true);
   });
 
   test('test invalid speed format', () {
@@ -155,10 +166,10 @@ void main() {
       ],
     );
 
-    expect(speedData.speedsFor(TrainSeries.R, 100)!.incomingSpeeds[0].speed, 100);
-    expect(speedData.speedsFor(TrainSeries.R, 150)!.incomingSpeeds[0].speed, 150);
-    expect(speedData.speedsFor(TrainSeries.A, 100)!.incomingSpeeds[0].speed, 200);
-    expect(speedData.speedsFor(TrainSeries.A, 150)!.incomingSpeeds[0].speed, 250);
+    expect(speedData.speedsFor(TrainSeries.R, 100)!.incomingSpeeds[0].speed, '100');
+    expect(speedData.speedsFor(TrainSeries.R, 150)!.incomingSpeeds[0].speed, '150');
+    expect(speedData.speedsFor(TrainSeries.A, 100)!.incomingSpeeds[0].speed, '200');
+    expect(speedData.speedsFor(TrainSeries.A, 150)!.incomingSpeeds[0].speed, '250');
   });
 
   test('Test resolved speed default break series', () {
@@ -171,16 +182,16 @@ void main() {
       ],
     );
 
-    expect(speedData.speedsFor(TrainSeries.R, 100)!.incomingSpeeds[0].speed, 100);
-    expect(speedData.speedsFor(TrainSeries.R, 150)!.incomingSpeeds[0].speed, 150);
-    expect(speedData.speedsFor(TrainSeries.R, 50)!.incomingSpeeds[0].speed, 150);
-    expect(speedData.speedsFor(TrainSeries.A, 100)!.incomingSpeeds[0].speed, 200);
-    expect(speedData.speedsFor(TrainSeries.A, 150)!.incomingSpeeds[0].speed, 250);
-    expect(speedData.speedsFor(TrainSeries.A, 80)!.incomingSpeeds[0].speed, 200);
+    expect(speedData.speedsFor(TrainSeries.R, 100)!.incomingSpeeds[0].speed, '100');
+    expect(speedData.speedsFor(TrainSeries.R, 150)!.incomingSpeeds[0].speed, '150');
+    expect(speedData.speedsFor(TrainSeries.R, 50)!.incomingSpeeds[0].speed, '150');
+    expect(speedData.speedsFor(TrainSeries.A, 100)!.incomingSpeeds[0].speed, '200');
+    expect(speedData.speedsFor(TrainSeries.A, 150)!.incomingSpeeds[0].speed, '250');
+    expect(speedData.speedsFor(TrainSeries.A, 80)!.incomingSpeeds[0].speed, '200');
   });
 }
 
-void checkSpeed(Speed speed, int speedValue, {bool isCircled = false, bool isSquared = false}) {
+void checkSpeed(Speed speed, String speedValue, {bool isCircled = false, bool isSquared = false}) {
   expect(speed.speed, speedValue);
   expect(speed.isCircled, isCircled);
   expect(speed.isSquared, isSquared);

--- a/das_client/sfera/test_resources/T5_breaking_series/SFERA_JP_T5.xml
+++ b/das_client/sfera/test_resources/T5_breaking_series/SFERA_JP_T5.xml
@@ -7,7 +7,7 @@
             <teltsi_StartDate>2022-01-04</teltsi_StartDate>
         </OTN_ID>
     </TrainIdentification>
-    <SegmentProfileReference SP_ID="T5_1" SP_VersionMajor="2" SP_VersionMinor="0" SP_Direction="Nominal">
+    <SegmentProfileReference SP_ID="T5_1" SP_VersionMajor="2" SP_VersionMinor="2" SP_Direction="Nominal">
         <SP_Zone>
             <IM_ID>0085</IM_ID>
         </SP_Zone>

--- a/das_client/sfera/test_resources/T5_breaking_series/SFERA_SP_T5_1.xml
+++ b/das_client/sfera/test_resources/T5_breaking_series/SFERA_SP_T5_1.xml
@@ -37,6 +37,7 @@
                 &lt;v trainSeries=&quot;R&quot; speed=&quot;44&quot;/&gt;
                 &lt;v trainSeries=&quot;A&quot; speed=&quot;55&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; speed=&quot;66&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/curveSpeed&gt;
             "/>
@@ -70,6 +71,7 @@
                 &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                 &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/lineSpeed&gt;
             "/>
@@ -87,6 +89,7 @@
                 &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;135&quot; speed=&quot;70&quot;/&gt;
                 &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;150&quot; speed=&quot;75&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/lineSpeed&gt;
             "/>
@@ -102,6 +105,7 @@
                 &lt;speeds&gt;
                 &lt;v trainSeries=&quot;R&quot; speed=&quot;44&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; speed=&quot;66&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/curveSpeed&gt;
             "/>
@@ -133,7 +137,7 @@
     </SP_Points>
     <SP_Areas>
         <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="500" endLocation="500" TAF_TAP_location_abbreviation="GENA"
-            TAF_TAP_location_type="station">
+                          TAF_TAP_location_type="station">
             <TAF_TAP_LocationIdent>
                 <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
                 <teltsi_LocationPrimaryCode>3002</teltsi_LocationPrimaryCode>
@@ -160,13 +164,14 @@
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>
         </TAF_TAP_Location>
 
         <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="1000" endLocation="1000" TAF_TAP_location_abbreviation="GEN"
-            TAF_TAP_location_type="station">
+                          TAF_TAP_location_type="station">
             <TAF_TAP_LocationIdent>
                 <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
                 <teltsi_LocationPrimaryCode>3003</teltsi_LocationPrimaryCode>
@@ -183,13 +188,14 @@
                     &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;135&quot; speed=&quot;70&quot;/&gt;
                     &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;150&quot; speed=&quot;75&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>
         </TAF_TAP_Location>
 
         <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="1500" endLocation="1500" TAF_TAP_location_abbreviation="GLA"
-            TAF_TAP_location_type="station">
+                          TAF_TAP_location_type="station">
             <TAF_TAP_LocationIdent>
                 <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
                 <teltsi_LocationPrimaryCode>3004</teltsi_LocationPrimaryCode>
@@ -216,6 +222,7 @@
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>

--- a/das_client/sfera/test_resources/T5_breaking_series/SFERA_SP_T5_1.xml
+++ b/das_client/sfera/test_resources/T5_breaking_series/SFERA_SP_T5_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../SFERA_v3.00.xsd" SP_ID="T5_1" SP_VersionMajor="2"
-                SP_VersionMinor="0" SP_Length="2000" SP_Status="Valid">
+                SP_VersionMinor="2" SP_Length="2000" SP_Status="Valid">
     <SP_Zone>
         <IM_ID>0085</IM_ID>
     </SP_Zone>

--- a/das_client/sfera/test_resources/T8_graduated_station_speeds/SFERA_JP_T8.xml
+++ b/das_client/sfera/test_resources/T8_graduated_station_speeds/SFERA_JP_T8.xml
@@ -7,7 +7,7 @@
             <teltsi_StartDate>2025-01-01</teltsi_StartDate>
         </OTN_ID>
     </TrainIdentification>
-    <SegmentProfileReference SP_ID="T8_1" SP_VersionMajor="2" SP_VersionMinor="2" SP_Direction="Nominal">
+    <SegmentProfileReference SP_ID="T8_1" SP_VersionMajor="2" SP_VersionMinor="3" SP_Direction="Nominal">
         <SP_Zone>
             <IM_ID>0085</IM_ID>
         </SP_Zone>

--- a/das_client/sfera/test_resources/T8_graduated_station_speeds/SFERA_SP_T8_1.xml
+++ b/das_client/sfera/test_resources/T8_graduated_station_speeds/SFERA_SP_T8_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../SFERA_v3.00.xsd" SP_ID="T8_1" SP_VersionMajor="2"
-                SP_VersionMinor="2" SP_Length="2000" SP_Status="Valid">
+                SP_VersionMinor="3" SP_Length="2000" SP_Status="Valid">
     <SP_Zone>
         <IM_ID>0085</IM_ID>
     </SP_Zone>
@@ -108,12 +108,14 @@
                     &lt;v trainSeries=&quot;O&quot; speed=&quot;75-{70}/[60]&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; speed=&quot;70&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; speed=&quot;70&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; speed=&quot;75-{XX}/[XX]&quot;/&gt;
                     &lt;/stationSpeed&gt;
                 "/>
                 <NetworkSpecificParameter name="xmlGraduatedSpeedInfo" value="
                     &lt;entries&gt;
                     &lt;entry roSpeed=&quot;75-{70}/[60]&quot; text=&quot;Zusatzinformation A&quot;/&gt;
                     &lt;entry adSpeed=&quot;70&quot; text=&quot;Zusatzinformation B&quot;/&gt;
+                    &lt;entry nSpeed=&quot;75-{XX}/[XX]&quot; text=&quot;Zusatzinformation C&quot;/&gt;
                     &lt;/entries&gt;
                 "/>
             </TAF_TAP_Location_NSP>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_JP_T5.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_JP_T5.xml
@@ -7,7 +7,7 @@
             <teltsi_StartDate>2022-01-04</teltsi_StartDate>
         </OTN_ID>
     </TrainIdentification>
-    <SegmentProfileReference SP_ID="T5_1" SP_VersionMajor="2" SP_VersionMinor="1" SP_Direction="Nominal">
+    <SegmentProfileReference SP_ID="T5_1" SP_VersionMajor="2" SP_VersionMinor="2" SP_Direction="Nominal">
         <SP_Zone>
             <IM_ID>0085</IM_ID>
         </SP_Zone>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_SP_T5_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_SP_T5_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T5_1" SP_VersionMajor="2"
-                SP_VersionMinor="0" SP_Length="2000" SP_Status="Valid">
+                SP_VersionMinor="2" SP_Length="2000" SP_Status="Valid">
     <SP_Zone>
         <IM_ID>0085</IM_ID>
     </SP_Zone>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_SP_T5_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T5_breaking_series/SFERA_SP_T5_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T5_1" SP_VersionMajor="2"
-                SP_VersionMinor="1" SP_Length="2000" SP_Status="Valid">
+                SP_VersionMinor="0" SP_Length="2000" SP_Status="Valid">
     <SP_Zone>
         <IM_ID>0085</IM_ID>
     </SP_Zone>
@@ -37,6 +37,7 @@
                 &lt;v trainSeries=&quot;R&quot; speed=&quot;44&quot;/&gt;
                 &lt;v trainSeries=&quot;A&quot; speed=&quot;55&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; speed=&quot;66&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/curveSpeed&gt;
             "/>
@@ -70,6 +71,7 @@
                 &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                 &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/lineSpeed&gt;
             "/>
@@ -87,6 +89,7 @@
                 &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;135&quot; speed=&quot;70&quot;/&gt;
                 &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;150&quot; speed=&quot;75&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/lineSpeed&gt;
             "/>
@@ -102,6 +105,7 @@
                 &lt;speeds&gt;
                 &lt;v trainSeries=&quot;R&quot; speed=&quot;44&quot;/&gt;
                 &lt;v trainSeries=&quot;D&quot; speed=&quot;66&quot;/&gt;
+                &lt;v trainSeries=&quot;N&quot; speed=&quot;XX&quot;/&gt;
                 &lt;/speeds&gt;
                 &lt;/curveSpeed&gt;
             "/>
@@ -160,6 +164,7 @@
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>
@@ -183,6 +188,7 @@
                     &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;135&quot; speed=&quot;70&quot;/&gt;
                     &lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;150&quot; speed=&quot;75&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>
@@ -216,6 +222,7 @@
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;105&quot; speed=&quot;100&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; brakeSeries=&quot;115&quot; speed=&quot;105&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; brakeSeries=&quot;30&quot; speed=&quot;77&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;30&quot; speed=&quot;XX&quot;/&gt;
                     &lt;/lineSpeed&gt;
                 "/>
             </TAF_TAP_Location_NSP>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T8_graduated_station_speeds/SFERA_JP_T8.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T8_graduated_station_speeds/SFERA_JP_T8.xml
@@ -7,7 +7,7 @@
             <teltsi_StartDate>2025-01-01</teltsi_StartDate>
         </OTN_ID>
     </TrainIdentification>
-    <SegmentProfileReference SP_ID="T8_1" SP_VersionMajor="2" SP_VersionMinor="2" SP_Direction="Nominal">
+    <SegmentProfileReference SP_ID="T8_1" SP_VersionMajor="2" SP_VersionMinor="3" SP_Direction="Nominal">
         <SP_Zone>
             <IM_ID>0085</IM_ID>
         </SP_Zone>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T8_graduated_station_speeds/SFERA_SP_T8_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T8_graduated_station_speeds/SFERA_SP_T8_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T8_1" SP_VersionMajor="2"
-                SP_VersionMinor="2" SP_Length="2000" SP_Status="Valid">
+                SP_VersionMinor="3" SP_Length="2000" SP_Status="Valid">
     <SP_Zone>
         <IM_ID>0085</IM_ID>
     </SP_Zone>
@@ -108,12 +108,14 @@
                     &lt;v trainSeries=&quot;O&quot; speed=&quot;75-{70}/[60]&quot;/&gt;
                     &lt;v trainSeries=&quot;A&quot; speed=&quot;70&quot;/&gt;
                     &lt;v trainSeries=&quot;D&quot; speed=&quot;70&quot;/&gt;
+                    &lt;v trainSeries=&quot;N&quot; speed=&quot;75-{XX}/[XX]&quot;/&gt;
                     &lt;/stationSpeed&gt;
                 "/>
                 <NetworkSpecificParameter name="xmlGraduatedSpeedInfo" value="
                     &lt;entries&gt;
                     &lt;entry roSpeed=&quot;75-{70}/[60]&quot; text=&quot;Zusatzinformation A&quot;/&gt;
                     &lt;entry adSpeed=&quot;70&quot; text=&quot;Zusatzinformation B&quot;/&gt;
+                    &lt;entry nSpeed=&quot;75-{XX}/[XX]&quot; text=&quot;Zusatzinformation C&quot;/&gt;
                     &lt;/entries&gt;
                 "/>
             </TAF_TAP_Location_NSP>


### PR DESCRIPTION
This PR allows the client to parse speed data with 'XX' instead of an empty or integer speed value.