### PR TITLE
feat: contactList over multiple SP (#1004)

### DIFF
--- a/das_client/sfera/lib/src/data/mapper/sfera_model_mapper.dart
+++ b/das_client/sfera/lib/src/data/mapper/sfera_model_mapper.dart
@@ -405,17 +405,11 @@ class SferaModelMapper {
 
           final contactLists = segmentProfile.contextInformation?.contactLists;
           return contactLists?.map((contactList) {
-            if (contactList.startLocation != contactList.endLocation) {
-              _log.warning(
-                'ContactList found without identical location (start=${contactList.startLocation} end=${contactList.endLocation}).',
-              );
-            }
-
             final identifiableContacts = contactList.contacts.where(
               (c) => c.otherContactType != null && c.otherContactType!.contactIdentifier != null,
             );
             return RadioContactList(
-              order: calculateOrder(index, contactList.startLocation!),
+              order: calculateOrder(index, contactList.startLocation ?? 0),
               contacts: identifiableContacts.map(
                 (e) => switch (e.mainContact) {
                   true => MainContact(

--- a/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
+++ b/das_client/sfera/test/src/data/mapper/sfera_model_mapper_test.dart
@@ -1223,17 +1223,27 @@ void main() {
   });
 
   test('Test CommunicationNetworks parsed correctly', () async {
-    final journey = getJourney('T12', 1);
+    final journey = getJourney('T12', 4);
     expect(journey.valid, true);
 
     final networkChanges = journey.metadata.communicationNetworkChanges;
-    expect(networkChanges, hasLength(3));
+    expect(networkChanges, hasLength(8));
     expect(networkChanges[0].order, 1000);
     expect(networkChanges[0].type, CommunicationNetworkType.gsmP);
     expect(networkChanges[1].order, 1500);
     expect(networkChanges[1].type, CommunicationNetworkType.sim);
     expect(networkChanges[2].order, 2000);
     expect(networkChanges[2].type, CommunicationNetworkType.gsmR);
+    expect(networkChanges[3].order, 100100);
+    expect(networkChanges[3].type, CommunicationNetworkType.gsmP);
+    expect(networkChanges[4].order, 100500);
+    expect(networkChanges[4].type, CommunicationNetworkType.sim);
+    expect(networkChanges[5].order, 200300);
+    expect(networkChanges[5].type, CommunicationNetworkType.sim);
+    expect(networkChanges[6].order, 300100);
+    expect(networkChanges[6].type, CommunicationNetworkType.sim);
+    expect(networkChanges[7].order, 300500);
+    expect(networkChanges[7].type, CommunicationNetworkType.gsmR);
   });
 
   test('Test opFootNote parsed correctly', () async {
@@ -1318,12 +1328,12 @@ void main() {
   });
 
   test('Test ContactList T12 parsed correctly', () async {
-    final journey = getJourney('T12', 1);
+    final journey = getJourney('T12', 4);
     expect(journey.valid, true);
 
     final radioContactLists = journey.metadata.radioContactLists.toList();
 
-    expect(radioContactLists.length, 3);
+    expect(radioContactLists.length, 8);
     expect(radioContactLists[0].mainContacts.length, 1);
     expect(radioContactLists[0].mainContacts.first.contactIdentifier, '1407');
     expect(radioContactLists[1].mainContacts.length, 3);
@@ -1332,6 +1342,22 @@ void main() {
     expect(radioContactLists[2].selectiveContacts.length, 3);
     expect(radioContactLists[2].selectiveContacts.first.contactIdentifier, '1103');
     expect(radioContactLists[2].selectiveContacts.first.contactRole, 'Richtung Süd: Fahrdienstleiter');
+    expect(radioContactLists[3].mainContacts.length, 1);
+    expect(radioContactLists[3].mainContacts.first.contactIdentifier, '1407');
+    expect(radioContactLists[4].mainContacts.length, 1);
+    expect(radioContactLists[4].selectiveContacts.length, 3);
+    expect(radioContactLists[4].selectiveContacts.first.contactIdentifier, '1103');
+    expect(radioContactLists[4].selectiveContacts.first.contactRole, 'Richtung Süd: Fahrdienstleiter');
+    expect(radioContactLists[5].mainContacts.length, 1);
+    expect(radioContactLists[5].selectiveContacts.length, 3);
+    expect(radioContactLists[5].selectiveContacts.first.contactIdentifier, '1103');
+    expect(radioContactLists[5].selectiveContacts.first.contactRole, 'Richtung Süd: Fahrdienstleiter');
+    expect(radioContactLists[6].mainContacts.length, 1);
+    expect(radioContactLists[6].selectiveContacts.length, 3);
+    expect(radioContactLists[6].selectiveContacts.first.contactIdentifier, '1103');
+    expect(radioContactLists[6].selectiveContacts.first.contactRole, 'Richtung Süd: Fahrdienstleiter');
+    expect(radioContactLists[7].mainContacts.length, 1);
+    expect(radioContactLists[7].mainContacts.first.contactIdentifier, '1407');
   });
 
   test('Test DecisiveGradientArea parsed correctly', () {

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_1000.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_1000.xml
@@ -1,1 +1,0 @@
-../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_1000.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_10000.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_10000.xml
@@ -1,1 +1,0 @@
-../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_10000.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_15000.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_15000.xml
@@ -1,1 +1,0 @@
-../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_15000.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_5000.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_Event_T12_5000.xml
@@ -1,1 +1,0 @@
-../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_5000.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_2.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_2.xml
@@ -1,0 +1,1 @@
+../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_2.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_3.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_3.xml
@@ -1,0 +1,1 @@
+../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_3.xml

--- a/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_4.xml
+++ b/das_client/sfera/test_resources/T12_radio_communication/SFERA_SP_T12_4.xml
@@ -1,0 +1,1 @@
+../../../../sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_4.xml

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_17500.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_17500.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_1" location="2500">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_19000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_19000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_2" location="50">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_20000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_20000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_2" location="100">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_23000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_23000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_2" location="500">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_25000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_25000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_2" location="550">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_26000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_26000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_3" location="50">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_26500.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_26500.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_3" location="300">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_28000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_28000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_3" location="500">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_30000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_30000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_3" location="800">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_32000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_32000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_4" location="50">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_32750.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_32750.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_4" location="100">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_33500.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_33500.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_4" location="200">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_35500.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_Event_T12_35500.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1085</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T12</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-01-01</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T12_4" location="500">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_JP_T12.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_JP_T12.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" JP_Status="Valid" JP_Version="2" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" JP_Status="Valid" JP_Version="3" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
     <TrainIdentification>
         <OTN_ID>
             <teltsi_Company>1085</teltsi_Company>
@@ -15,25 +15,106 @@
             <TimingPointReference>
                 <TP_ID_Reference TP_ID="Bern"/>
             </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T00:02:00Z" plannedDepartureTime="9999-01-01T00:02:00Z"/>
         </TimingPointConstraints>
-        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+        <TimingPointConstraints TP_StopSkipPass="Passing_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:12:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:12:00Z">
             <TimingPointReference>
                 <TP_ID_Reference TP_ID="Wankdorf"/>
             </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T00:12:30Z" plannedDepartureTime="9999-01-01T00:12:30Z"/>
         </TimingPointConstraints>
-        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+        <TimingPointConstraints TP_StopSkipPass="Passing_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:23:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:23:00Z">
             <TimingPointReference>
                 <TP_ID_Reference TP_ID="Burgdorf"/>
             </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T00:23:30Z" plannedDepartureTime="9999-01-01T00:23:30Z"/>
         </TimingPointConstraints>
-        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+        <TimingPointConstraints TP_StopSkipPass="Passing_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:38:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:38:00Z">
             <TimingPointReference>
                 <TP_ID_Reference TP_ID="Olten"/>
             </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T00:38:30Z" plannedDepartureTime="9999-01-01T00:38:30Z"/>
         </TimingPointConstraints>
-        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:58:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:58:00Z">
             <TimingPointReference>
                 <TP_ID_Reference TP_ID="Zuerich"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:05:00Z" plannedDepartureTime="9999-01-01T01:05:00Z"/>
+        </TimingPointConstraints>
+        <TrainCharacteristicsRef TC_ID="T12_1" TC_VersionMajor="2" TC_VersionMinor="0" location="0">
+            <TC_RU_ID>1185</TC_RU_ID>
+        </TrainCharacteristicsRef>
+    </SegmentProfileReference>
+    <SegmentProfileReference SP_ID="T12_2" SP_VersionMajor="2" SP_VersionMinor="0" SP_Direction="Nominal">
+        <SP_Zone>
+            <IM_ID>0085</IM_ID>
+        </SP_Zone>
+        <TimingPointConstraints TP_StopSkipPass="Passing_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T01:10:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T01:10:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="ZOER"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:10:30Z" plannedDepartureTime="9999-01-01T01:10:30Z"/>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T01:14:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T01:14:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="ZFH"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:16:00Z" plannedDepartureTime="9999-01-01T01:16:00Z"/>
+        </TimingPointConstraints>
+        <TrainCharacteristicsRef TC_ID="T12_1" TC_VersionMajor="2" TC_VersionMinor="0" location="0">
+            <TC_RU_ID>1185</TC_RU_ID>
+        </TrainCharacteristicsRef>
+    </SegmentProfileReference>
+    <SegmentProfileReference SP_ID="T12_3" SP_VersionMajor="2" SP_VersionMinor="0" SP_Direction="Nominal">
+        <SP_Zone>
+            <IM_ID>0085</IM_ID>
+        </SP_Zone>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T01:29:00Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T01:29:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="W"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:31:00Z" plannedDepartureTime="9999-01-01T01:31:00Z"/>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T01:42:20Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T01:42:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="FF"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:42:00Z" plannedDepartureTime="9999-01-01T01:42:00Z"/>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T01:54:10Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T01:54:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="WF"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T01:55:00Z" plannedDepartureTime="9999-01-01T01:55:00Z"/>
+        </TimingPointConstraints>
+        <TrainCharacteristicsRef TC_ID="T12_1" TC_VersionMajor="2" TC_VersionMinor="0" location="0">
+            <TC_RU_ID>1185</TC_RU_ID>
+        </TrainCharacteristicsRef>
+    </SegmentProfileReference>
+    <SegmentProfileReference SP_ID="T12_4" SP_VersionMajor="2" SP_VersionMinor="0" SP_Direction="Nominal">
+        <SP_Zone>
+            <IM_ID>0085</IM_ID>
+        </SP_Zone>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T02:06:20Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T02:06:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="AW"/>
+            </TimingPointReference>
+            <StoppingPointDepartureDetails departureTime="9999-01-01T02:06:00Z" plannedDepartureTime="9999-01-01T02:06:00Z"/>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T02:12:40Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T02:12:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="RH"/>
             </TimingPointReference>
         </TimingPointConstraints>
         <TrainCharacteristicsRef TC_ID="T12_1" TC_VersionMajor="2" TC_VersionMinor="0" location="0">

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_2.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_2.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T12_2" SP_VersionMajor="2"
+                SP_VersionMinor="0" SP_Length="600" SP_Status="Valid">
+    <SP_Zone>
+        <IM_ID>0085</IM_ID>
+    </SP_Zone>
+    <SP_Points>
+        <TimingPoint TP_ID="ZOER" location="100">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>3006</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <TimingPoint TP_ID="ZFH" location="500">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>3016</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <Signal>
+            <Signal_ID signal_ID_Physical="L312" location="600"/>
+            <SignalFunction>intermediate</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="L312"/>
+        </Signal>
+        
+    </SP_Points>
+    <SP_Areas>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="100" endLocation="100" TAF_TAP_location_abbreviation="ZOER"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>3006</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Zürich Oerlikon</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="500" endLocation="500" TAF_TAP_location_abbreviation="ZFH"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>3016</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Zürich Flughafen</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+    </SP_Areas>
+
+    <SP_ContextInformation>
+        <ContactList startEndQualifier="StartsEnds" startLocation="100" endLocation="100">
+            <Contact mainContact="true">
+                <OtherContactType contactIdentifier="1407"/>
+            </Contact>
+        </ContactList>
+        <ContactList startEndQualifier="StartsEnds" startLocation="500" endLocation="600">
+            <Contact mainContact="true">
+                <OtherContactType contactIdentifier="1102"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Süd: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1103"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Nord: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1104"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Rangierbahnhof: Fahrdienstleiter Stellwerk 3">
+                <OtherContactType contactIdentifier="1105"/>
+            </Contact>
+        </ContactList>
+        <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="100" endLocation="100" communicationNetworkType="GSM-P"/>
+        <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="500" endLocation="500" communicationNetworkType="SIM"/>
+
+        <KilometreReferencePoint location="100">
+            <KM_Reference kmRef="48.2"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="500">
+            <KM_Reference kmRef="40.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="600">
+            <KM_Reference kmRef="39.5"/>
+        </KilometreReferencePoint>
+
+    </SP_ContextInformation>
+</SegmentProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_2.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_2.xml
@@ -19,11 +19,16 @@
         </TimingPoint>
 
         <Signal>
-            <Signal_ID signal_ID_Physical="L312" location="600"/>
+            <Signal_ID signal_ID_Physical="L312" location="50"/>
             <SignalFunction>intermediate</SignalFunction>
             <SignalPhysicalCharacteristics visualIdentifier="L312"/>
         </Signal>
-        
+        <Signal>
+            <Signal_ID signal_ID_Physical="1" location="550"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B1"/>
+        </Signal>
+
     </SP_Points>
     <SP_Areas>
         <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="100" endLocation="100" TAF_TAP_location_abbreviation="ZOER"
@@ -68,17 +73,19 @@
         <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="100" endLocation="100" communicationNetworkType="GSM-P"/>
         <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="500" endLocation="500" communicationNetworkType="SIM"/>
 
+        <KilometreReferencePoint location="50">
+            <KM_Reference kmRef="49.5"/>
+        </KilometreReferencePoint>
         <KilometreReferencePoint location="100">
             <KM_Reference kmRef="48.2"/>
         </KilometreReferencePoint>
-
         <KilometreReferencePoint location="500">
             <KM_Reference kmRef="40.5"/>
         </KilometreReferencePoint>
-
-        <KilometreReferencePoint location="600">
-            <KM_Reference kmRef="39.5"/>
+        <KilometreReferencePoint location="550">
+            <KM_Reference kmRef="40.1"/>
         </KilometreReferencePoint>
+
 
     </SP_ContextInformation>
 </SegmentProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_3.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_3.xml
@@ -25,7 +25,7 @@
         </TimingPoint>
 
         <Signal>
-            <Signal_ID signal_ID_Physical="L324" location="600"/>
+            <Signal_ID signal_ID_Physical="L324" location="50"/>
             <SignalFunction>intermediate</SignalFunction>
             <SignalPhysicalCharacteristics visualIdentifier="L324"/>
         </Signal>
@@ -77,14 +77,14 @@
         </ContactList>
         <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="300" endLocation="300" communicationNetworkType="SIM"/>
 
+        <KilometreReferencePoint location="50">
+            <KM_Reference kmRef="99.1"/>
+        </KilometreReferencePoint>
         <KilometreReferencePoint location="300">
             <KM_Reference kmRef="98.2"/>
         </KilometreReferencePoint>
         <KilometreReferencePoint location="500">
             <KM_Reference kmRef="80.5"/>
-        </KilometreReferencePoint>
-        <KilometreReferencePoint location="600">
-            <KM_Reference kmRef="58.1"/>
         </KilometreReferencePoint>
         <KilometreReferencePoint location="800">
             <KM_Reference kmRef="49.4"/>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_3.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_3.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T12_3" SP_VersionMajor="2"
+                SP_VersionMinor="0" SP_Length="900" SP_Status="Valid">
+    <SP_Zone>
+        <IM_ID>0085</IM_ID>
+    </SP_Zone>
+    <SP_Points>
+        <TimingPoint TP_ID="W" location="300">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6000</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <TimingPoint TP_ID="FF" location="500">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6100</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <TimingPoint TP_ID="WF" location="800">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6105</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <Signal>
+            <Signal_ID signal_ID_Physical="L324" location="600"/>
+            <SignalFunction>intermediate</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="L324"/>
+        </Signal>
+
+    </SP_Points>
+    <SP_Areas>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="300" endLocation="300" TAF_TAP_location_abbreviation="W"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6000</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Winterthur</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="500" endLocation="500" TAF_TAP_location_abbreviation="FF"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6100</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Frauenfeld</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="800" endLocation="800" TAF_TAP_location_abbreviation="WF"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6105</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Weinfelden</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+    </SP_Areas>
+
+    <SP_ContextInformation>
+        <ContactList startEndQualifier="WholeSP">
+            <Contact mainContact="true">
+                <OtherContactType contactIdentifier="1102"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Süd: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1103"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Nord: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1104"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Rangierbahnhof: Fahrdienstleiter Stellwerk 3">
+                <OtherContactType contactIdentifier="1105"/>
+            </Contact>
+        </ContactList>
+        <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="300" endLocation="300" communicationNetworkType="SIM"/>
+
+        <KilometreReferencePoint location="300">
+            <KM_Reference kmRef="98.2"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="500">
+            <KM_Reference kmRef="80.5"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="600">
+            <KM_Reference kmRef="58.1"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="800">
+            <KM_Reference kmRef="49.4"/>
+        </KilometreReferencePoint>
+
+    </SP_ContextInformation>
+</SegmentProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_4.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_4.xml
@@ -19,9 +19,14 @@
         </TimingPoint>
 
         <Signal>
-            <Signal_ID signal_ID_Physical="L989" location="200"/>
+            <Signal_ID signal_ID_Physical="L989" location="50"/>
             <SignalFunction>intermediate</SignalFunction>
             <SignalPhysicalCharacteristics visualIdentifier="L989"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="1" location="200"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B1"/>
         </Signal>
 
     </SP_Points>
@@ -68,14 +73,15 @@
         <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="100" endLocation="100" communicationNetworkType="SIM"/>
         <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="500" endLocation="500" communicationNetworkType="GSM-R"/>
 
+        <KilometreReferencePoint location="50">
+            <KM_Reference kmRef="12.0"/>
+        </KilometreReferencePoint>
         <KilometreReferencePoint location="100">
             <KM_Reference kmRef="11.2"/>
         </KilometreReferencePoint>
-
         <KilometreReferencePoint location="200">
             <KM_Reference kmRef="7.3"/>
         </KilometreReferencePoint>
-
         <KilometreReferencePoint location="500">
             <KM_Reference kmRef="6.5"/>
         </KilometreReferencePoint>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_4.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T12_radio_communication/SFERA_SP_T12_4.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd" SP_ID="T12_4" SP_VersionMajor="2"
+                SP_VersionMinor="0" SP_Length="300" SP_Status="Valid">
+    <SP_Zone>
+        <IM_ID>0085</IM_ID>
+    </SP_Zone>
+    <SP_Points>
+        <TimingPoint TP_ID="AW" location="100">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6109</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <TimingPoint TP_ID="RH" location="500">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6121</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <Signal>
+            <Signal_ID signal_ID_Physical="L989" location="200"/>
+            <SignalFunction>intermediate</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="L989"/>
+        </Signal>
+
+    </SP_Points>
+    <SP_Areas>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="100" endLocation="100" TAF_TAP_location_abbreviation="AW"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6109</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Amriswil</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="500" endLocation="500" TAF_TAP_location_abbreviation="RH"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>6121</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Romanshorn</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+    </SP_Areas>
+
+    <SP_ContextInformation>
+        <ContactList startEndQualifier="StartsEnds" startLocation="0" endLocation="100">
+            <Contact mainContact="true">
+                <OtherContactType contactIdentifier="1102"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Süd: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1103"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Richtung Nord: Fahrdienstleiter">
+                <OtherContactType contactIdentifier="1104"/>
+            </Contact>
+            <Contact mainContact="false" contactRole="Rangierbahnhof: Fahrdienstleiter Stellwerk 3">
+                <OtherContactType contactIdentifier="1105"/>
+            </Contact>
+        </ContactList>
+        <ContactList startEndQualifier="StartsEnds" startLocation="500" endLocation="500">
+            <Contact mainContact="true">
+                <OtherContactType contactIdentifier="1407"/>
+            </Contact>
+        </ContactList>
+        <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="100" endLocation="100" communicationNetworkType="SIM"/>
+        <CommunicationNetwork startEndQualifier="StartsEnds" startLocation="500" endLocation="500" communicationNetworkType="GSM-R"/>
+
+        <KilometreReferencePoint location="100">
+            <KM_Reference kmRef="11.2"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="200">
+            <KM_Reference kmRef="7.3"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="500">
+            <KM_Reference kmRef="6.5"/>
+        </KilometreReferencePoint>
+
+    </SP_ContextInformation>
+</SegmentProfile>


### PR DESCRIPTION
This PR allows handling and displaying contact lists that stretch over multiple SPs ("WholeSP") and have startLocation != endLocation.

Mainly, only T12 is adapted. The displaying logic has not changed. Refer to comments in #1004 for more information.

Integration tests will be adapted within #940.