### PR TITLE
chore: fix sticky header test with key search

### DIFF
--- a/das_client/app/integration_test/test/train_journey_table_test.dart
+++ b/das_client/app/integration_test/test/train_journey_table_test.dart
@@ -13,6 +13,7 @@ import 'package:app/pages/journey/train_journey/widgets/table/whistle_row.dart';
 import 'package:app/pages/journey/train_journey/widgets/train_journey.dart';
 import 'package:app/util/format.dart';
 import 'package:app/widgets/labeled_badge.dart';
+import 'package:app/widgets/stickyheader/sticky_header.dart';
 import 'package:app/widgets/table/das_table.dart';
 import 'package:app/widgets/table/das_table_cell.dart';
 import 'package:flutter/material.dart';
@@ -872,7 +873,12 @@ void main() {
       );
       expect(wankdorfOutgoingSpeedsEmpty, findsNothing);
 
-      await tester.dragUntilVisible(find.text('Zurich'), scrollableFinder, const Offset(0, -100));
+      final stickyHeader = find.byKey(StickyHeader.headerKey);
+      await tester.dragUntilVisible(
+        find.descendant(of: stickyHeader, matching: find.text('Wankdorf')),
+        scrollableFinder,
+        const Offset(0, -100),
+      );
 
       // now filled
       final wankdorfIncomingSpeedsFilled = find.descendant(

--- a/das_client/app/lib/widgets/stickyheader/sticky_header.dart
+++ b/das_client/app/lib/widgets/stickyheader/sticky_header.dart
@@ -12,6 +12,8 @@ import 'package:flutter/material.dart';
 typedef StickyWidgetBuilder = Widget Function(BuildContext context, int index);
 
 class StickyHeader extends StatefulWidget {
+  static const Key headerKey = Key('StickyHeaderHeader');
+
   final ScrollController scrollController;
   final StickyWidgetBuilder headerBuilder;
   final StickyWidgetBuilder? footerBuilder;
@@ -73,6 +75,7 @@ class StickyHeaderState extends State<StickyHeader> {
           child: widget.child,
         ),
         StickyWidget(
+          key: StickyHeader.headerKey,
           controller: controller,
           widgetBuilder: widget.headerBuilder,
         ),


### PR DESCRIPTION

Due to different screen sizes, test fails. Fixed with key search of header.