### PR TITLE
chore: adjust test data for lightweight testing (#1091)

### DIFF
--- a/sfera_mock/src/main/resources/static_sfera_resources/1513_OL_ZUE/SFERA_JP_1513.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/1513_OL_ZUE/SFERA_JP_1513.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" JP_Status="Valid" JP_Version="3" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
+<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" JP_Status="Valid" JP_Version="4" xsi:noNamespaceSchemaLocation="../../SFERA_v3.00.xsd">
     <TrainIdentification>
         <OTN_ID>
             <teltsi_Company>1285</teltsi_Company>
@@ -33,6 +33,16 @@
             <TC_RU_ID>1285</TC_RU_ID>
         </TrainCharacteristicsRef>
 
+        <JP_ContextInformation>
+            <!-- VPro for OL -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="120"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_2_Dulliken" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -46,6 +56,16 @@
                 <TP_ID_Reference TP_ID="Dulliken"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Dulliken -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="115"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_3_Daeniken" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -59,6 +79,16 @@
                 <TP_ID_Reference TP_ID="Daeniken"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Daeniken -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="120"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_4_Schoenenwerd" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -71,6 +101,16 @@
                 <TP_ID_Reference TP_ID="Schoenenwerd"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Schoenenwerd -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_5_Woeschnau" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -83,6 +123,16 @@
                 <TP_ID_Reference TP_ID="Woeschnau"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Woeschnau -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="145"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_6_Aarau" SP_VersionMajor="3" SP_VersionMinor="4" SP_Direction="Nominal">
@@ -101,6 +151,24 @@
                 <TP_ID_Reference TP_ID="Aarau_GB"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Aarau -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+            <!-- VPro for AarauGB -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="700" endLocation="700"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_7_Rupperswil" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -113,6 +181,16 @@
                 <TP_ID_Reference TP_ID="Rupperswil"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Rupperswil -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_8_Lenzburg" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -125,6 +203,16 @@
                 <TP_ID_Reference TP_ID="Lenzburg"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Lenzburg -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="125"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_9_Gexi" SP_VersionMajor="3" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -137,6 +225,16 @@
                 <TP_ID_Reference TP_ID="Gexi"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Gexi -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="125"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_10_Othmarsingen" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -149,6 +247,16 @@
                 <TP_ID_Reference TP_ID="Othmarsingen"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Othmarsingen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="130"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_11_Maegenwil" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -161,6 +269,16 @@
                 <TP_ID_Reference TP_ID="Maegenwil"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Maegenwil -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="125"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_12_Mellingen" SP_VersionMajor="3" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -173,6 +291,15 @@
                 <TP_ID_Reference TP_ID="Mellingen"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Mellingen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="125"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_13_Mellingen_Heitersberg" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -185,6 +312,15 @@
                 <TP_ID_Reference TP_ID="Mellingen_Heitersberg"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Mellingen_Heitersberg -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="125"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_14_Killwangen_Spreitenbach" SP_VersionMajor="3" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -197,6 +333,16 @@
                 <TP_ID_Reference TP_ID="Killwangen_Spreitenbach"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Killwangen_Spreitenbach -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_15_Dietikon" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -209,6 +355,15 @@
                 <TP_ID_Reference TP_ID="Dietikon"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Dietikon -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="130"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_16_Glanzenberg" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -221,6 +376,15 @@
                 <TP_ID_Reference TP_ID="Glanzenberg"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Glanzenberg -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="130"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_17_Schlieren" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -233,6 +397,15 @@
                 <TP_ID_Reference TP_ID="Schlieren"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Schlieren -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="130"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_18_Altstetten" SP_VersionMajor="3" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -245,6 +418,16 @@
                 <TP_ID_Reference TP_ID="Altstetten"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Altstetten -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="130"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_19_Hardbruecke" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -257,6 +440,16 @@
                 <TP_ID_Reference TP_ID="Hardbruecke"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Hardbruecke -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="1513_20_Zuerich_HB" SP_VersionMajor="3" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -270,6 +463,15 @@
                 <TP_ID_Reference TP_ID="Zuerich_HB"/>
             </TimingPointReference>
         </TimingPointConstraints>
+        <JP_ContextInformation>
+            <!-- VPro for Zuerich_HB -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
 </JourneyProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/1513_OL_ZUE/SFERA_SP_1513_20_Zuerich_HB.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/1513_OL_ZUE/SFERA_SP_1513_20_Zuerich_HB.xml
@@ -40,9 +40,10 @@
 				&lt;stationProperties&gt;
 					&lt;stationProperty text=&quot;&lt;b&gt;A&quot; sign=&quot;Q&quot;&gt;
 						&lt;speeds&gt; 
-							&lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;150&quot; speed=&quot;40-30&quot;/&gt; 
-							&lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;180&quot; speed=&quot;40-30&quot;/&gt; 
-						&lt;/speeds&gt; 
+							&lt;v trainSeries=&quot;R&quot; brakeSeries=&quot;150&quot; speed=&quot;40-30/80&quot;/&gt;
+							&lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;150&quot; speed=&quot;40-30/80&quot;/&gt;
+							&lt;v trainSeries=&quot;N&quot; brakeSeries=&quot;180&quot; speed=&quot;40-30/80&quot;/&gt;
+						&lt;/speeds&gt;
 					&lt;/stationProperty&gt;
 				&lt;/stationProperties&gt;
 				"/>

--- a/sfera_mock/src/main/resources/static_sfera_resources/15154_TH_FRI/SFERA_JP_15154.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/15154_TH_FRI/SFERA_JP_15154.xml
@@ -26,6 +26,16 @@
             <TC_RU_ID>1285</TC_RU_ID>
         </TrainCharacteristicsRef>
 
+        <JP_ContextInformation>
+            <!-- VPro for Thun -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_2_Uttigen" SP_VersionMajor="1" SP_VersionMinor="1" SP_Direction="Nominal">
@@ -46,6 +56,16 @@
             <TemporaryConstraintReason text="Umbau" language="DE"/>
         </TemporaryConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Uttigen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="160"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_3_Kiesen" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -60,6 +80,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T14:49:00Z" plannedDepartureTime="2025-05-17T14:49:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Kiesen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -76,6 +106,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T14:52:00Z" plannedDepartureTime="2025-05-17T14:52:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Wichtrach -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_5_Muensingen" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -90,6 +130,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T14:55:00Z" plannedDepartureTime="2025-05-17T14:55:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Muensingen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -106,6 +156,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T14:57:00Z" plannedDepartureTime="2025-05-17T14:57:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Rubigen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="155"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_7_Guemligen" SP_VersionMajor="1" SP_VersionMinor="1" SP_Direction="Nominal">
@@ -121,10 +181,20 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:03:00Z" plannedDepartureTime="2025-05-17T15:03:00Z"/>
         </TimingPointConstraints>
 
-		<TemporaryConstraints startEndQualifier="StartsEnds" temporaryConstraintType="ASR" startLocation="2200">
+        <TemporaryConstraints startEndQualifier="StartsEnds" temporaryConstraintType="ASR" startLocation="2200">
             <AdditionalSpeedRestriction ASR_Front="false" ASR_Speed="80"/>
             <TemporaryConstraintReason text="Umbau" language="DE"/>
         </TemporaryConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Guemligen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -140,10 +210,20 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:06:00Z" plannedDepartureTime="2025-05-17T15:06:00Z"/>
         </TimingPointConstraints>
-		
-		<TemporaryConstraints startEndQualifier="Ends" temporaryConstraintType="ASR" endLocation="450">
+
+        <TemporaryConstraints startEndQualifier="Ends" temporaryConstraintType="ASR" endLocation="450">
             <AdditionalSpeedRestriction ASR_Front="false" ASR_Speed="80"/>
         </TemporaryConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Ostermundigen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="105"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -158,6 +238,16 @@
                 <TP_ID_Reference TP_ID="Wankdorf"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Wankdorf -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="95"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_10_Bern_Wankdorf" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -173,6 +263,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:08:00Z" plannedDepartureTime="2025-05-17T15:08:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Bern_Wankdorf -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="95"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_11_Bern_Wyler" SP_VersionMajor="1" SP_VersionMinor="1" SP_Direction="Nominal">
@@ -186,6 +286,16 @@
                 <TP_ID_Reference TP_ID="Bern_Wyler"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Bern_Wyler -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="95"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_12_Bern" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -201,6 +311,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:15:00Z" plannedDepartureTime="2025-05-17T15:15:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Bern -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="70"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_13_Bern_Whaus" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -214,6 +334,16 @@
                 <TP_ID_Reference TP_ID="Bern_Whaus"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Bern_Whaus -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_14_Bern_Europaplatz" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -228,6 +358,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:19:00Z" plannedDepartureTime="2025-05-17T15:19:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Bern_Europaplatz -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -244,6 +384,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:21:00Z" plannedDepartureTime="2025-05-17T15:21:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Buempliz_Sued -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_16_Niederwangen" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -259,6 +409,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:23:00Z" plannedDepartureTime="2025-05-17T15:23:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Niederwangen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_17_Oberwangen" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -272,6 +432,16 @@
                 <TP_ID_Reference TP_ID="Oberwangen"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Oberwangen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="135"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_18_Thoerishaus" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -285,6 +455,16 @@
                 <TP_ID_Reference TP_ID="Thoerishaus"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Thoerishaus -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="90"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_19_Thoerishaus_Dorf" SP_VersionMajor="1" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -299,6 +479,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:26:00Z" plannedDepartureTime="2025-05-17T15:26:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Thoerishaus_Dorf -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="105"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -315,6 +505,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:29:00Z" plannedDepartureTime="2025-05-17T15:29:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Flamatt -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="100"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_21_Wuennewil" SP_VersionMajor="1" SP_VersionMinor="1" SP_Direction="Nominal">
@@ -329,6 +529,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:32:00Z" plannedDepartureTime="2025-05-17T15:32:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Wuennewil -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="100"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -345,6 +555,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:35:00Z" plannedDepartureTime="2025-05-17T15:35:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Schmitten -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="105"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_23_Duedingen" SP_VersionMajor="1" SP_VersionMinor="2" SP_Direction="Nominal">
@@ -359,6 +579,16 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:40:00Z" plannedDepartureTime="2025-05-17T15:40:00Z"/>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Duedingen -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="105"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 
@@ -375,6 +605,16 @@
             <StoppingPointDepartureDetails departureTime="2025-05-17T15:44:00Z" plannedDepartureTime="2025-05-17T15:44:00Z"/>
         </TimingPointConstraints>
 
+        <JP_ContextInformation>
+            <!-- VPro for Fribourg_Freiburg_Poya -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="105"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+
     </SegmentProfileReference>
 
     <SegmentProfileReference SP_ID="15154_25_Fribourg_Freiburg" SP_VersionMajor="1" SP_VersionMinor="3" SP_Direction="Nominal">
@@ -388,6 +628,16 @@
                 <TP_ID_Reference TP_ID="Fribourg_Freiburg"/>
             </TimingPointReference>
         </TimingPointConstraints>
+
+        <JP_ContextInformation>
+            <!-- VPro for Fribourg_Freiburg -->
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="95"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="0" endLocation="0"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
 
     </SegmentProfileReference>
 

--- a/sfera_mock/src/main/resources/static_sfera_resources/T9999_mixed_journey/SFERA_JP_T9999.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T9999_mixed_journey/SFERA_JP_T9999.xml
@@ -17,7 +17,7 @@
             </TimingPointReference>
             <StoppingPointDepartureDetails departureTime="9999-01-01T00:00:02Z" plannedDepartureTime="9999-01-01T00:00:10Z"/>
         </TimingPointConstraints>
-        <TrainCharacteristicsRef TC_ID="T9999_1" TC_VersionMajor="3" TC_VersionMinor="0" location="0">
+        <TrainCharacteristicsRef TC_ID="T9999_1" TC_VersionMajor="1" TC_VersionMinor="0" location="0">
             <TC_RU_ID>1085</TC_RU_ID>
         </TrainCharacteristicsRef>
         <JP_ContextInformation>


### PR DESCRIPTION
As described in #1091:

* VPro speeds for 1513
* VPro speeds for 15154
* stationProperty for Zürich HB in 1513 for R150