### PR TITLE
fix: color on next stop with additional speed restriction (#1147)

### DIFF
--- a/das_client/app/lib/pages/journey/train_journey/widgets/reduced_overview/rows/reduced_service_point_row.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/reduced_overview/rows/reduced_service_point_row.dart
@@ -48,7 +48,6 @@ class ReducedServicePointRow extends ServicePointRow {
         isRouteEnd: metadata.routeEnd == data,
         isStopOnRequest: !data.mandatoryStop,
         chevronPosition: RouteChevron.positionFromHeight(height),
-        isNextStop: false,
       ),
     );
   }

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cell_row_builder.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cell_row_builder.dart
@@ -15,6 +15,7 @@ import 'package:app/widgets/das_text_styles.dart';
 import 'package:app/widgets/speed_display.dart';
 import 'package:app/widgets/table/das_table_cell.dart';
 import 'package:app/widgets/table/das_table_row.dart';
+import 'package:app/widgets/table/das_table_theme.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -78,17 +79,17 @@ class CellRowBuilder<T extends JourneyPoint> extends DASTableRowBuilder<T> {
       return DASTableCell.empty(color: specialCellColor);
     }
 
+    final textColor = _isNextStop && specialCellColor == null ? SBBColors.white : null;
+    final defaultTextStyle = DASTableTheme.of(context)?.data.dataTextStyle;
+    final textStyle = (defaultTextStyle ?? DASTextStyles.largeRoman).copyWith(color: textColor);
     return DASTableCell(
       color: specialCellColor,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            data.kilometre[0].toStringAsFixed(1),
-            style: _isNextStop ? DASTextStyles.largeRoman.copyWith(color: SBBColors.white) : DASTextStyles.largeRoman,
-          ),
-          if (data.kilometre.length > 1) Text(data.kilometre[1].toStringAsFixed(1)),
+          Text(data.kilometre[0].toStringAsFixed(1), style: textStyle),
+          if (data.kilometre.length > 1) Text(data.kilometre[1].toStringAsFixed(1), style: textStyle),
         ],
       ),
       alignment: Alignment.centerLeft,
@@ -122,7 +123,7 @@ class CellRowBuilder<T extends JourneyPoint> extends DASTableRowBuilder<T> {
       alignment: null,
       child: TrackEquipmentCellBody(
         renderData: config.trackEquipmentRenderData!,
-        isNextStop: _isNextStop,
+        lineColor: _isNextStop && specialCellColor == null ? SBBColors.white : null,
       ),
     );
   }

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/advised_speed_cell_body.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/advised_speed_cell_body.dart
@@ -49,10 +49,11 @@ class AdvisedSpeedCellBody extends StatelessWidget {
       speed = _resolvedTrainSeriesSpeed();
     }
 
+    final defaultTextStyle = DASTableTheme.of(context)?.data.dataTextStyle ?? DASTextStyles.largeRoman;
     return Text(
       speed?.value ?? '',
       key: nonEmptyKey,
-      style: isNextStop ? DASTextStyles.largeRoman.copyWith(color: SBBColors.white) : DASTextStyles.largeRoman,
+      style: defaultTextStyle.copyWith(color: isNextStop ? SBBColors.white : null),
     );
   }
 
@@ -82,13 +83,9 @@ class AdvisedSpeedCellBody extends StatelessWidget {
           bottom: -horizontalBorderWidth * 2,
           left: 0,
           right: 0,
-          child: Container(
-            color: SBBColors.iron,
-          ),
+          child: Container(color: SBBColors.iron),
         ),
-        Center(
-          child: child,
-        ),
+        Center(child: child),
       ],
     );
   }

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/route_cell_body.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/route_cell_body.dart
@@ -25,7 +25,7 @@ class RouteCellBody extends StatelessWidget {
     this.isRouteStart = false,
     this.isRouteEnd = false,
     this.chevronAnimationData,
-    this.isNextStop = false,
+    this.routeColor,
   });
 
   final double chevronWidth;
@@ -37,15 +37,16 @@ class RouteCellBody extends StatelessWidget {
   final bool isStopOnRequest;
   final bool isRouteStart;
   final bool isRouteEnd;
-  final bool isNextStop;
+
+  final Color? routeColor;
 
   final ChevronAnimationData? chevronAnimationData;
 
   @override
   Widget build(BuildContext context) {
-    if (!isNextStop) return _route();
+    if (routeColor != null) return _coloredRoute(_route());
 
-    return _invertedColors(_route());
+    return _route();
   }
 
   Widget _route() {
@@ -66,9 +67,9 @@ class RouteCellBody extends StatelessWidget {
     );
   }
 
-  Widget _invertedColors(Widget child) {
+  Widget _coloredRoute(Widget child) {
     return ColorFiltered(
-      colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcATop),
+      colorFilter: ColorFilter.mode(routeColor!, BlendMode.srcATop),
       child: child,
     );
   }

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/time_cell_body.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/time_cell_body.dart
@@ -5,7 +5,6 @@ import 'package:app/widgets/das_text_styles.dart';
 import 'package:app/widgets/table/das_table_cell.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
 import 'package:sfera/component.dart';
 
 class TimeCellBody extends StatelessWidget {
@@ -15,14 +14,14 @@ class TimeCellBody extends StatelessWidget {
     required this.times,
     required this.viewModel,
     required this.showTimesInBrackets,
-    this.isNextStop = false,
+    this.fontColor,
     super.key,
   });
 
   final ArrivalDepartureTime times;
   final ArrivalDepartureTimeViewModel viewModel;
   final bool showTimesInBrackets;
-  final bool isNextStop;
+  final Color? fontColor;
 
   @override
   Widget build(BuildContext context) {
@@ -45,7 +44,6 @@ class TimeCellBody extends StatelessWidget {
 
         final isArrivalBold = departureTime.isEmpty && !showOperationalTime;
         final isDepartureUnderlined = currentTime.isAfterOrSameToTheMinute(times.plannedDepartureTime);
-        final color = isNextStop ? SBBColors.white : null;
 
         return Text.rich(
           key: timeCellKey,
@@ -54,14 +52,14 @@ class TimeCellBody extends StatelessWidget {
               TextSpan(
                 text: arrivalTime,
                 style: isArrivalBold
-                    ? DASTextStyles.largeBold.copyWith(color: color)
-                    : DASTextStyles.largeRoman.copyWith(color: color),
+                    ? DASTextStyles.largeBold.copyWith(color: fontColor)
+                    : DASTextStyles.largeRoman.copyWith(color: fontColor),
               ),
               TextSpan(
                 text: departureTime,
                 style: DASTextStyles.largeBold.copyWith(
                   decoration: isDepartureUnderlined ? TextDecoration.underline : TextDecoration.none,
-                  color: color,
+                  color: fontColor,
                 ),
               ),
             ],

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/track_equipment_cell_body.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/track_equipment_cell_body.dart
@@ -4,7 +4,6 @@ import 'package:app/pages/journey/train_journey/widgets/table/config/track_equip
 import 'package:app/theme/theme_util.dart';
 import 'package:app/widgets/table/das_table_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
 import 'package:sfera/component.dart';
 
 class TrackEquipmentCellBody extends StatelessWidget {
@@ -18,13 +17,15 @@ class TrackEquipmentCellBody extends StatelessWidget {
   const TrackEquipmentCellBody({
     this.renderData = const TrackEquipmentRenderData(),
     this.position,
-    this.isNextStop = false,
+    this.lineColor,
     super.key,
   });
 
   final TrackEquipmentRenderData renderData;
   final double? position;
-  final bool isNextStop;
+
+  /// optional line color. [ThemeUtil.getIconColor] is used otherwise
+  final Color? lineColor;
 
   @override
   Widget build(BuildContext context) {
@@ -198,7 +199,7 @@ class TrackEquipmentCellBody extends StatelessWidget {
 
   static double get conventionalExtendedSpeedBorderSpace => 5.0 + _ConventionalExtendedSpeedBorderPainter.height;
 
-  Color _lineColor(BuildContext context) => isNextStop ? SBBColors.white : ThemeUtil.getIconColor(context);
+  Color _lineColor(BuildContext context) => lineColor ?? ThemeUtil.getIconColor(context);
 }
 
 class _ConventionalExtendedSpeedBorderPainter extends CustomPainter {

--- a/das_client/app/lib/widgets/table/scrollable_align.dart
+++ b/das_client/app/lib/widgets/table/scrollable_align.dart
@@ -40,7 +40,7 @@ class _ScrollableAlignState extends State<ScrollableAlign> {
         onNotification: (_) {
           // Delay scroll back by 1 Frame to avoid strange behaviour
           if (!isTouching && !isAnimating) {
-            Future.delayed(Duration(milliseconds: 1), () => alignToElement());
+            Future.delayed(Duration(milliseconds: 1), () => _alignToElement());
           }
           return false;
         },
@@ -49,7 +49,7 @@ class _ScrollableAlignState extends State<ScrollableAlign> {
     );
   }
 
-  void alignToElement() async {
+  void _alignToElement() async {
     final widgetOffset = WidgetUtil.findOffsetOfKey(key);
     final stickyHeaderState = StickyHeader.of(context);
 
@@ -80,8 +80,7 @@ class _ScrollableAlignState extends State<ScrollableAlign> {
       return;
     }
 
-    for (int i = 0; i < widget.rows.length; i++) {
-      final row = widget.rows[i];
+    for (final row in widget.rows) {
       if (row.key.currentContext != null) {
         final renderObject = row.key.currentContext?.findRenderObject() as RenderBox?;
         if (renderObject != null) {


### PR DESCRIPTION
This PR fixes white color on colored cells of additional speed restrictions on a next stop. Fixed:

<img width="1060" height="342" alt="Bildschirmfoto 2025-08-18 um 14 40 22" src="https://github.com/user-attachments/assets/170ce459-26d2-49c0-b268-b59debe24271" />

PS: All service points on screenshot are set to next stop for testing :)