### PR TITLE
chore: changed chevron position to end of row (#662)

### DIFF
--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/route_chevron.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/cells/route_chevron.dart
@@ -21,7 +21,8 @@ class RouteChevron extends StatefulWidget {
 
   final ChevronAnimationData? chevronAnimationData;
 
-  static double positionFromHeight(double height) => height - chevronHeight * 0.5;
+  // additional -1.5 because line overdraws a bit from rotation
+  static double positionFromHeight(double height) => height - chevronHeight - 1.5;
 
   @override
   State<RouteChevron> createState() => _RouteChevronState();

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/config/chevron_animation_data.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/config/chevron_animation_data.dart
@@ -36,10 +36,9 @@ class ChevronAnimationData {
 
     final fromIndex = rows.indexOf(lastPosition);
     final toIndex = rows.indexOf(currentPosition);
-    final calculateToIndex = toIndex + 1; // overlapping of next row
 
     final currentIndex = rows.indexOf(currentRow);
-    if (currentIndex < fromIndex || currentIndex > calculateToIndex) {
+    if (currentIndex < fromIndex || currentIndex > toIndex) {
       return null;
     }
 
@@ -79,14 +78,6 @@ class ChevronAnimationData {
     if (currentRow == currentPosition) {
       startOffset = -endOffset;
       endOffset = 0.0;
-    }
-
-    // show end of overlapping chevron on row after current position
-    if (currentIndex == calculateToIndex) {
-      final overlappedRow = rows[calculateToIndex];
-      final overlappedRowHeight = CellRowBuilder.rowHeightForData(overlappedRow, currentBreakSeries);
-      startOffset = -endOffset - overlappedRowHeight;
-      endOffset = -overlappedRowHeight;
     }
 
     return ChevronAnimationData(


### PR DESCRIPTION
Moved chevron position to end of row instead of between two rows as this lead to different problems that will be addressed in the story #1194