### PR TITLE
chore: expand collapsed content of operational indication on tap on row 

### DIFF
--- a/das_client/app/integration_test/test/train_journey_table_adl_test.dart
+++ b/das_client/app/integration_test/test/train_journey_table_adl_test.dart
@@ -1,7 +1,6 @@
 import 'package:app/pages/journey/train_journey/widgets/header/das_chronograph.dart';
 import 'package:app/pages/journey/train_journey/widgets/notification/adl_notification.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/cells/advised_speed_cell_body.dart';
-import 'package:app/pages/journey/train_journey/widgets/table/cells/calculated_speed_cell_body.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../app_test.dart';
@@ -66,15 +65,13 @@ void main() {
 
     // Check that adl end displayed calculated speed on signal row
     final adlEndRow = findDASTableRowByText('A653');
-    await waitUntilExists(tester, _findNonEmptyCalculatedSpeedCellOf(adlEndRow));
-    _findTextWithin(adlEndRow, '110');
+    await waitUntilExists(tester, _findCalculatedSpeedCellOf(adlEndRow, '110'));
 
     await dragUntilTextInStickyHeader(tester, 'Rolle');
 
     // Check that adl end displayed calculated speed on signal row
     final adlEndRowServicePoint = findDASTableRowByText('Allaman');
-    await waitUntilExists(tester, _findNonEmptyCalculatedSpeedCellOf(adlEndRowServicePoint), maxWaitSeconds: 30);
-    _findTextWithin(adlEndRowServicePoint, '100');
+    await waitUntilExists(tester, _findCalculatedSpeedCellOf(adlEndRowServicePoint, '100'), maxWaitSeconds: 30);
 
     await disconnect(tester);
   });
@@ -99,9 +96,9 @@ Finder _findNonEmptyAdvisedSpeedCellOf(Finder baseFinder) {
   );
 }
 
-Finder _findNonEmptyCalculatedSpeedCellOf(Finder baseFinder) {
+Finder _findCalculatedSpeedCellOf(Finder baseFinder, String speed) {
   return find.descendant(
     of: baseFinder,
-    matching: find.byKey(CalculatedSpeedCellBody.nonEmptyKey),
+    matching: find.textContaining(speed),
   );
 }

--- a/das_client/app/integration_test/test/train_journey_table_collapsible_rows_test.dart
+++ b/das_client/app/integration_test/test/train_journey_table_collapsible_rows_test.dart
@@ -46,33 +46,33 @@ void main() {
     await dragUntilTextInStickyHeader(tester, 'Pully');
 
     // should not be collapsed by default
-    final collapsibleRow = _findDASTableAccordionRowByContainsText(textToSearch);
-    _checkCollapsibleRow(isCollapsed: false, collapsibleRow: collapsibleRow);
+    final accordion = _findDASTableAccordionByContainsText(textToSearch, UncodedOperationalIndicationAccordion);
+    _checkCollapsibleRow(isCollapsed: false, collapsibleRow: accordion);
 
     // should have show more button and collapsed content
     final collapsedContent = find.descendant(
-      of: collapsibleRow,
+      of: accordion,
       matching: find.byKey(UncodedOperationalIndicationAccordion.collapsedContentKey),
     );
     expect(collapsedContent, findsOneWidget);
     var showMoreButton = find.descendant(
-      of: collapsibleRow,
-      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreButtonKey),
+      of: accordion,
+      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreTextKey),
     );
     expect(showMoreButton, findsOneWidget);
 
-    // should show full text after tap on "show more" and no button
-    await tester.pumpAndSettle(ScrollableAlign.alignScrollDuration);
+    // should show full text after tap on row and no button
     await tapElement(tester, showMoreButton);
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(ScrollableAlign.alignScrollDuration);
 
-    final rowWithExpandedText = _findDASTableAccordionRowByContainsText(
+    final rowWithExpandedText = _findDASTableAccordionByContainsText(
       'Lorem ipsum dolor sit amet, consetetur sadipscing elitr',
+      UncodedOperationalIndicationAccordion,
     );
     expect(rowWithExpandedText, findsOneWidget);
     showMoreButton = find.descendant(
-      of: collapsibleRow,
-      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreButtonKey),
+      of: rowWithExpandedText,
+      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreTextKey),
     );
     expect(showMoreButton, findsNothing);
 
@@ -86,25 +86,26 @@ void main() {
     await dragUntilTextInStickyHeader(tester, 'Lausanne');
 
     // should have show more button and collapsed content with " ;" delimiter
-    final collapsibleRow = _findDASTableAccordionRowByContainsText(
+    final accordion = _findDASTableAccordionByContainsText(
       'Strecke INN - MR: Bahnübergangsanlagen ohne Balisenüberwachung; Straba. = Strassenbahnbereich;',
+      UncodedOperationalIndicationAccordion,
     );
     final collapsedContent = find.descendant(
-      of: collapsibleRow,
+      of: accordion,
       matching: find.byKey(UncodedOperationalIndicationAccordion.collapsedContentKey),
     );
     expect(collapsedContent, findsOneWidget);
     final showMoreButton = find.descendant(
-      of: collapsibleRow,
-      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreButtonKey),
+      of: accordion,
+      matching: find.byKey(UncodedOperationalIndicationAccordion.showMoreTextKey),
     );
     expect(showMoreButton, findsOneWidget);
 
     // should show full content without " ;" after tap on show more
-    await tester.pumpAndSettle(ScrollableAlign.alignScrollDuration);
-    await tapElement(tester, showMoreButton);
-    final expandedRow = _findDASTableAccordionRowByContainsText(
+    await tapElement(tester, accordion);
+    final expandedRow = _findDASTableAccordionByContainsText(
       'Strecke INN - MR: Bahnübergangsanlagen ohne Balisenüberwachung\nStraba. = Strassenbahnbereich',
+      UncodedOperationalIndicationAccordion,
     );
     expect(expandedRow, findsOneWidget);
 
@@ -225,9 +226,9 @@ Finder _findDASTableAccordionRowByKey(Object identifier) {
   );
 }
 
-Finder _findDASTableAccordionRowByContainsText(String text) {
+Finder _findDASTableAccordionByContainsText(String text, Type accordion) {
   return find.descendant(
     of: find.byKey(DASTable.tableKey),
-    matching: find.ancestor(of: find.textContaining(text, findRichText: true), matching: find.byKey(DASTable.rowKey)),
+    matching: find.ancestor(of: find.textContaining(text, findRichText: true), matching: find.byType(accordion)),
   );
 }

--- a/das_client/app/integration_test/util/test_utils.dart
+++ b/das_client/app/integration_test/util/test_utils.dart
@@ -7,6 +7,7 @@ import 'package:app/pages/journey/train_journey/widgets/header/start_pause_butto
 import 'package:app/pages/journey/train_journey/widgets/train_journey.dart';
 import 'package:app/widgets/stickyheader/sticky_header.dart';
 import 'package:app/widgets/table/das_table.dart';
+import 'package:app/widgets/table/scrollable_align.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -189,7 +190,7 @@ Future<void> dragUntilTextInStickyHeader(WidgetTester tester, String textToSearc
     const Offset(0, -50),
     maxIteration: 100,
   );
-  await tester.pumpAndSettle();
+  await tester.pumpAndSettle(ScrollableAlign.alignScrollDuration);
 }
 
 extension _FlutterErrorExtension on FlutterError {

--- a/das_client/app/lib/main.dart
+++ b/das_client/app/lib/main.dart
@@ -31,11 +31,13 @@ void runDasApp() => runApp(App());
 Future<void> _initDASLogging(Flavor flavor) async {
   final deviceId = await DeviceIdInfo.getDeviceId();
   final logPrinter = LogPrinter(appName: 'DAS ${flavor.displayName}', isDebugMode: kDebugMode);
-  final dasLogger = LoggerComponent.createDasLogger(deviceId: deviceId);
-
   Logger.root.level = flavor.logLevel;
   Logger.root.onRecord.listen(logPrinter.call);
-  Logger.root.onRecord.listen(dasLogger.call);
+
+  if (!kDebugMode) {
+    final dasLogger = LoggerComponent.createDasLogger(deviceId: deviceId);
+    Logger.root.onRecord.listen(dasLogger.call);
+  }
 }
 
 Future<void> _initDependencyInjection(Flavor flavor) async {

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/combined_foot_note_operational_indication_row.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/combined_foot_note_operational_indication_row.dart
@@ -1,25 +1,13 @@
+import 'package:app/pages/journey/train_journey/collapsible_rows_view_model.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/foot_note_accordion.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/foot_note_row.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/uncoded_operational_indication_accordion.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/widget_row_builder.dart';
 import 'package:app/theme/theme_util.dart';
-import 'package:app/widgets/accordion/accordion.dart';
 import 'package:app/widgets/stickyheader/sticky_level.dart';
 import 'package:flutter/material.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
 import 'package:sfera/component.dart';
-
-class AccordionConfig {
-  AccordionConfig({
-    required this.isExpanded,
-    required this.toggleCallback,
-    this.isContentExpanded = false,
-  });
-
-  final bool isExpanded;
-  final bool isContentExpanded;
-  final AccordionToggleCallback toggleCallback;
-}
 
 class CombinedFootNoteOperationalIndicationRow extends WidgetRowBuilder<CombinedFootNoteOperationalIndication> {
   static const Key rowKey = Key('combinedFootNoteOperationalIndicationRow');
@@ -28,8 +16,8 @@ class CombinedFootNoteOperationalIndicationRow extends WidgetRowBuilder<Combined
     required super.rowIndex,
     required super.metadata,
     required super.data,
-    required this.footNoteConfig,
-    required this.operationIndicationConfig,
+    required this.footNoteState,
+    required this.operationIndicationState,
     super.config,
     super.identifier,
   }) : super(
@@ -37,19 +25,18 @@ class CombinedFootNoteOperationalIndicationRow extends WidgetRowBuilder<Combined
          height:
              UncodedOperationalIndicationAccordion.calculateHeight(
                data.operationalIndication.combinedText,
-               isExpanded: operationIndicationConfig.isExpanded,
-               expandedContent: operationIndicationConfig.isContentExpanded,
+               collapsedState: operationIndicationState,
                addTopMargin: true,
              ) +
              FootNoteAccordion.calculateHeight(
                data: data.footNote,
-               isExpanded: footNoteConfig.isExpanded,
+               isExpanded: footNoteState != CollapsedState.collapsed,
                addTopMargin: false,
              ),
        );
 
-  final AccordionConfig footNoteConfig;
-  final AccordionConfig operationIndicationConfig;
+  final CollapsedState footNoteState;
+  final CollapsedState operationIndicationState;
 
   @override
   Widget buildRowWidget(BuildContext context) {
@@ -59,17 +46,14 @@ class CombinedFootNoteOperationalIndicationRow extends WidgetRowBuilder<Combined
       child: Column(
         children: [
           UncodedOperationalIndicationAccordion(
-            isExpanded: operationIndicationConfig.isExpanded,
-            expandedContent: operationIndicationConfig.isContentExpanded,
+            collapsedState: operationIndicationState,
             addTopMargin: true,
-            accordionToggleCallback: operationIndicationConfig.toggleCallback,
             data: data.operationalIndication,
           ),
           FootNoteAccordion(
             title: data.footNote.title(context, metadata),
-            isExpanded: footNoteConfig.isExpanded,
+            isExpanded: footNoteState != CollapsedState.collapsed,
             addTopMargin: false,
-            accordionToggleCallback: footNoteConfig.toggleCallback,
             data: data.footNote,
           ),
         ],

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/foot_note_accordion.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/foot_note_accordion.dart
@@ -1,9 +1,11 @@
+import 'package:app/pages/journey/train_journey/collapsible_rows_view_model.dart';
 import 'package:app/pages/journey/train_journey/train_journey_overview.dart';
 import 'package:app/theme/theme_util.dart';
 import 'package:app/util/text_util.dart';
 import 'package:app/widgets/accordion/accordion.dart';
 import 'package:app/widgets/das_text_styles.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
 import 'package:sfera/component.dart';
 
@@ -15,7 +17,6 @@ class FootNoteAccordion extends StatelessWidget {
     required this.title,
     required this.addTopMargin,
     required this.isExpanded,
-    required this.accordionToggleCallback,
     super.key,
   });
 
@@ -23,7 +24,6 @@ class FootNoteAccordion extends StatelessWidget {
   final String title;
   final bool addTopMargin;
   final bool isExpanded;
-  final AccordionToggleCallback accordionToggleCallback;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +32,7 @@ class FootNoteAccordion extends StatelessWidget {
       title: title,
       body: contentText(data),
       isExpanded: isExpanded,
-      toggleCallback: accordionToggleCallback,
+      toggleCallback: () => context.read<CollapsibleRowsViewModel>().toggleRow(data),
       icon: SBBIcons.form_small,
       margin: EdgeInsets.only(
         bottom: _verticalMargin,

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/foot_note_row.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/foot_note_row.dart
@@ -2,7 +2,6 @@ import 'package:app/i18n/i18n.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/foot_note_accordion.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/widget_row_builder.dart';
 import 'package:app/theme/theme_util.dart';
-import 'package:app/widgets/accordion/accordion.dart';
 import 'package:app/widgets/stickyheader/sticky_level.dart';
 import 'package:flutter/material.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -15,7 +14,6 @@ class FootNoteRow<T extends BaseFootNote> extends WidgetRowBuilder<T> {
     required super.rowIndex,
     required this.isExpanded,
     required this.addTopMargin,
-    required this.accordionToggleCallback,
     super.config,
     super.identifier,
   }) : super(
@@ -29,7 +27,6 @@ class FootNoteRow<T extends BaseFootNote> extends WidgetRowBuilder<T> {
 
   final bool addTopMargin;
   final bool isExpanded;
-  final AccordionToggleCallback accordionToggleCallback;
 
   @override
   Widget buildRowWidget(BuildContext context) {
@@ -40,7 +37,6 @@ class FootNoteRow<T extends BaseFootNote> extends WidgetRowBuilder<T> {
         title: data.title(context, metadata),
         addTopMargin: addTopMargin,
         isExpanded: isExpanded,
-        accordionToggleCallback: accordionToggleCallback,
       ),
     );
   }

--- a/das_client/app/lib/pages/journey/train_journey/widgets/table/uncoded_operational_indication_row.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/table/uncoded_operational_indication_row.dart
@@ -1,7 +1,7 @@
+import 'package:app/pages/journey/train_journey/collapsible_rows_view_model.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/uncoded_operational_indication_accordion.dart';
 import 'package:app/pages/journey/train_journey/widgets/table/widget_row_builder.dart';
 import 'package:app/theme/theme_util.dart';
-import 'package:app/widgets/accordion/accordion.dart';
 import 'package:app/widgets/stickyheader/sticky_level.dart';
 import 'package:flutter/material.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -12,36 +12,29 @@ class UncodedOperationalIndicationRow extends WidgetRowBuilder<UncodedOperationa
     required super.rowIndex,
     required super.metadata,
     required super.data,
-    required this.isExpanded,
-    required this.accordionToggleCallback,
+    required this.collapsedState,
     required this.addTopMargin,
-    this.expandedContent = false,
     super.config,
     super.identifier,
   }) : super(
          stickyLevel: StickyLevel.second,
          height: UncodedOperationalIndicationAccordion.calculateHeight(
            data.combinedText,
-           isExpanded: isExpanded,
-           expandedContent: expandedContent,
+           collapsedState: collapsedState,
            addTopMargin: addTopMargin,
          ),
        );
 
-  final bool isExpanded;
-  final bool expandedContent;
+  final CollapsedState collapsedState;
   final bool addTopMargin;
-  final AccordionToggleCallback accordionToggleCallback;
 
   @override
   Widget buildRowWidget(BuildContext context) {
     return Container(
       color: ThemeUtil.getColor(context, SBBColors.milk, SBBColors.black),
       child: UncodedOperationalIndicationAccordion(
-        isExpanded: isExpanded,
-        expandedContent: expandedContent,
+        collapsedState: collapsedState,
         addTopMargin: addTopMargin,
-        accordionToggleCallback: accordionToggleCallback,
         data: data,
       ),
     );

--- a/das_client/app/lib/pages/journey/train_journey/widgets/train_journey.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/train_journey.dart
@@ -319,9 +319,8 @@ class TrainJourney extends StatelessWidget {
             metadata: journey.metadata,
             data: rowData as BaseFootNote,
             config: trainJourneyConfig,
-            isExpanded: collapsedRows.isExpanded(rowData.hashCode),
+            isExpanded: collapsedRows.stateOf(rowData) != CollapsedState.collapsed,
             addTopMargin: !hasPreviousAnnotation,
-            accordionToggleCallback: () => context.read<CollapsibleRowsViewModel>().toggleRow(rowData),
             rowIndex: index,
           );
         case Datatype.uncodedOperationalIndication:
@@ -329,10 +328,8 @@ class TrainJourney extends StatelessWidget {
             metadata: journey.metadata,
             data: rowData as UncodedOperationalIndication,
             config: trainJourneyConfig,
-            expandedContent: collapsedRows.isContentExpanded(rowData.hashCode),
-            isExpanded: collapsedRows.isExpanded(rowData.hashCode),
+            collapsedState: collapsedRows.stateOf(rowData),
             addTopMargin: !hasPreviousAnnotation,
-            accordionToggleCallback: () => context.read<CollapsibleRowsViewModel>().toggleRow(rowData),
             rowIndex: index,
           );
         case Datatype.combinedFootNoteOperationalIndication:
@@ -340,15 +337,8 @@ class TrainJourney extends StatelessWidget {
             rowIndex: index,
             metadata: journey.metadata,
             data: rowData as CombinedFootNoteOperationalIndication,
-            footNoteConfig: AccordionConfig(
-              isExpanded: collapsedRows.isExpanded(rowData.footNote.hashCode),
-              toggleCallback: () => context.read<CollapsibleRowsViewModel>().toggleRow(rowData.footNote),
-            ),
-            operationIndicationConfig: AccordionConfig(
-              isExpanded: collapsedRows.isExpanded(rowData.operationalIndication.hashCode),
-              isContentExpanded: collapsedRows.isContentExpanded(rowData.operationalIndication.hashCode),
-              toggleCallback: () => context.read<CollapsibleRowsViewModel>().toggleRow(rowData.operationalIndication),
-            ),
+            footNoteState: collapsedRows.stateOf(rowData.footNote),
+            operationIndicationState: collapsedRows.stateOf(rowData.operationalIndication),
           );
       }
     });

--- a/das_client/app/lib/widgets/table/scrollable_align.dart
+++ b/das_client/app/lib/widgets/table/scrollable_align.dart
@@ -31,18 +31,15 @@ class _ScrollableAlignState extends State<ScrollableAlign> {
   Widget build(BuildContext context) {
     return Listener(
       key: key,
-      onPointerDown: (_) {
-        isTouching = true;
-      },
-      onPointerUp: (_) {
-        isTouching = false;
-      },
+      onPointerDown: (_) => isTouching = true,
+      onPointerUp: (_) => isTouching = false,
       child: NotificationListener<ScrollEndNotification>(
         onNotification: (_) {
-          // Delay scroll back by 1 Frame to avoid strange behaviour
           if (!isTouching && !isAnimating) {
+            // Delay scroll back by 1 Frame to avoid strange behaviour
             Future.delayed(Duration(milliseconds: 1), () => _alignToElement());
           }
+
           return false;
         },
         child: widget.child,
@@ -51,6 +48,8 @@ class _ScrollableAlignState extends State<ScrollableAlign> {
   }
 
   void _alignToElement() async {
+    if (!mounted) return;
+
     final widgetOffset = WidgetUtil.findOffsetOfKey(key);
     final stickyHeaderState = StickyHeader.of(context);
 


### PR DESCRIPTION
Additionally: 
* handles wrong calculation of height on collapsed content which fixes scrolling issues
* improves `StickyWidget` scroll handling which drastically reduces the amount of `ScrollEndNotification` that get fired
* don't log to Splunk on debug build