### PR TITLE
feat: show previous stop in header when on final stop of journey (#1231)

### DIFF
--- a/das_client/app/lib/pages/journey/train_journey/journey_position/journey_position_model.dart
+++ b/das_client/app/lib/pages/journey/train_journey/journey_position/journey_position_model.dart
@@ -6,6 +6,7 @@ class JourneyPositionModel {
     this.lastPosition,
     this.previousServicePoint,
     this.nextServicePoint,
+    this.previousStop,
     this.nextStop,
   });
 
@@ -22,6 +23,9 @@ class JourneyPositionModel {
   /// This is the service point closest to [currentPosition] that is still ahead.
   final ServicePoint? nextServicePoint;
 
+  /// This is service point closest to [currentPosition] that has already been passed and is a stop.
+  final ServicePoint? previousStop;
+
   /// This is service point closest to [currentPosition] that is still ahead and is a stop.
   final ServicePoint? nextStop;
 
@@ -33,6 +37,7 @@ class JourneyPositionModel {
           lastPosition == other.lastPosition &&
           previousServicePoint == other.previousServicePoint &&
           nextServicePoint == other.nextServicePoint &&
+          previousStop == other.previousStop &&
           nextStop == other.nextStop);
 
   @override
@@ -41,6 +46,7 @@ class JourneyPositionModel {
       lastPosition.hashCode ^
       previousServicePoint.hashCode ^
       nextServicePoint.hashCode ^
+      previousStop.hashCode ^
       nextStop.hashCode;
 
   @override
@@ -50,6 +56,7 @@ class JourneyPositionModel {
       ', lastPosition: $lastPosition'
       ', lastServicePoint: $previousServicePoint'
       ', nextServicePoint: $nextServicePoint'
+      ', previousStop: $previousStop'
       ', nextStop: $nextStop'
       ')';
 }

--- a/das_client/app/lib/pages/journey/train_journey/journey_position/journey_position_view_model.dart
+++ b/das_client/app/lib/pages/journey/train_journey/journey_position/journey_position_view_model.dart
@@ -71,6 +71,7 @@ class JourneyPositionViewModel {
             lastPosition: _calculateLastPosition(journey),
             previousServicePoint: _calculatePreviousServicePoint(updatedPosition, journey.journeyPoints),
             nextServicePoint: _calculateNextServicePoint(updatedPosition, journey.journeyPoints),
+            previousStop: _calculatePreviousStop(updatedPosition, journey.journeyPoints),
             nextStop: _calculateNextStop(updatedPosition, journey.journeyPoints),
           );
 
@@ -125,6 +126,14 @@ class JourneyPositionViewModel {
 
     return journeyPoints.whereType<ServicePoint>().toList().firstWhereOrNull(
       (sP) => sP.order > updatedPosition.order,
+    );
+  }
+
+  ServicePoint? _calculatePreviousStop(JourneyPoint? updatedPosition, List<JourneyPoint> journeyPoints) {
+    if (updatedPosition == null) return null;
+
+    return journeyPoints.whereType<ServicePoint>().toList().reversed.firstWhereOrNull(
+      (sP) => sP.order <= updatedPosition.order && sP.isStop,
     );
   }
 

--- a/das_client/app/lib/pages/journey/train_journey/widgets/header/next_stop.dart
+++ b/das_client/app/lib/pages/journey/train_journey/widgets/header/next_stop.dart
@@ -31,12 +31,14 @@ class NextStop extends StatelessWidget {
       initialData: viewModel.modelValue,
       builder: (context, asyncSnapshot) {
         if (!asyncSnapshot.hasData) return SizedBox.shrink();
-        final nextStop = asyncSnapshot.data?.nextStop;
+        final model = asyncSnapshot.data!;
+
+        final displayedStop = model.nextStop ?? model.previousStop; // if at last stop, show previous one
 
         return Padding(
           padding: const EdgeInsets.only(left: sbbDefaultSpacing * 0.5),
           child: Text(
-            nextStop?.name ?? context.l10n.c_unknown,
+            displayedStop?.name ?? context.l10n.c_unknown,
             style: DASTextStyles.xLargeLight,
             overflow: TextOverflow.ellipsis,
           ),

--- a/das_client/app/test/pages/journey/train_journey/journey_position/journey_position_view_model_test.dart
+++ b/das_client/app/test/pages/journey/train_journey/journey_position/journey_position_view_model_test.dart
@@ -441,6 +441,92 @@ void main() {
       expect(testee.modelValue?.nextServicePoint, equals(bServicePoint));
     });
 
+    test('previousStop_whenHasNoServicePoints_thenIsNull', () {
+      // ARRANGE
+      testAsync.run((_) {
+        rxMockJourney.add(
+          Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+            data: [zeroSignal, twentySignal],
+          ),
+        );
+      });
+      _processStreamInFakeAsync(testAsync);
+
+      // ACT & EXPECT
+      expect(testee.modelValue?.previousStop, isNull);
+    });
+
+    test('previousStop_whenIsOnServicePointThatIsNoStop_thenIsNull', () {
+      // ARRANGE
+      final aServicePoint = ServicePoint(name: 'a', order: 20, kilometre: []);
+      testAsync.run((_) {
+        rxMockJourney.add(
+          Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+            data: [zeroSignal, tenSignal, aServicePoint],
+          ),
+        );
+      });
+      _processStreamInFakeAsync(testAsync);
+
+      // ACT & EXPECT
+      expect(testee.modelValue?.previousStop, isNull);
+    });
+
+    test('previousStop_whenIsOnServicePointThatIsStopAndNoOther_thenIsThisServicePoint', () {
+      // ARRANGE
+      final aServicePoint = ServicePoint(name: 'a', order: 20, kilometre: [], isStop: true);
+      testAsync.run((_) {
+        rxMockJourney.add(
+          Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+            data: [zeroSignal, tenSignal, aServicePoint],
+          ),
+        );
+      });
+      _processStreamInFakeAsync(testAsync);
+
+      // ACT & EXPECT
+      expect(testee.modelValue?.previousStop, equals(aServicePoint));
+    });
+
+    test('previousStop_whenIsOnServicePointAndFutureOtherThatIsStop_thenIsCurrentOne', () {
+      // ARRANGE
+      final aServicePoint = ServicePoint(name: 'a', order: 20, kilometre: [], isStop: true);
+      final bServicePoint = ServicePoint(name: 'b', order: 25, kilometre: [], isStop: true);
+      testAsync.run((_) {
+        rxMockJourney.add(
+          Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+          ),
+        );
+      });
+      _processStreamInFakeAsync(testAsync);
+
+      // ACT & EXPECT
+      expect(testee.modelValue?.previousStop, equals(aServicePoint));
+    });
+
+    test('previousStop_whenIsOnServicePointAndHasPastOtherThatIsStop_thenIsCurrentOne', () {
+      // ARRANGE
+      final aServicePoint = ServicePoint(name: 'a', order: 20, kilometre: [], isStop: true);
+      final bServicePoint = ServicePoint(name: 'b', order: 25, kilometre: [], isStop: true);
+      testAsync.run((_) {
+        rxMockJourney.add(
+          Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
+            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+          ),
+        );
+      });
+      _processStreamInFakeAsync(testAsync);
+
+      // ACT & EXPECT
+      expect(testee.modelValue?.previousStop, equals(bServicePoint));
+    });
+
     test('nextStop_whenHasNoServicePoints_thenIsNull', () {
       // ARRANGE
       testAsync.run((_) {


### PR DESCRIPTION
An instrumentation test was deliberately left out, since testing with an existing test track that goes all the way until the last stop (e.g. T12) takes ~30s, which seems an overkill for something simple as this.

Also, adding a new test track just for this purpose seems like an overkill.

If really wanted, one could add an event and the corresponding test to an existing test track (e.g. T1) and change all instrumentation tests to use T1M.