### PR TITLE
chore: dependency upgrades

### DIFF
--- a/das_client/.fvmrc
+++ b/das_client/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.35.5",
+  "flutter": "3.35.6",
   "flavors": {}
 }

--- a/das_client/app/pubspec.yaml
+++ b/das_client/app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   # https://pub.dev/packages/android_id
   android_id: ^0.4.0
   # https://pub.dev/packages/auto_route
-  auto_route: ^10.1.2
+  auto_route: ^10.2.0
   # https://pub.dev/packages/battery_plus
   battery_plus: ^7.0.0
   # https://pub.dev/packages/collection
@@ -37,7 +37,7 @@ dependencies:
   # https://pub.dev/packages/clock
   clock: ^1.1.2
   # https://pub.dev/packages/device_info_plus
-  device_info_plus: ^12.1.0
+  device_info_plus: ^12.2.0
   # https://pub.dev/packages/extra_hittest_area
   extra_hittest_area: ^1.0.0
   # https://pub.dev/packages/logging
@@ -85,15 +85,15 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/auto_route_generator
-  auto_route_generator: ^10.2.4
+  auto_route_generator: ^10.2.5
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.7.0
+  build_runner: ^2.10.0
   # https://pub.dev/packages/flutter_launcher_icons
   flutter_launcher_icons: ^0.14.4
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/mockito
-  mockito: ^5.5.0
+  mockito: ^5.5.1
   # https://pub.dev/packages/fake_async
   fake_async: ^1.3.3
 

--- a/das_client/logger/pubspec.yaml
+++ b/das_client/logger/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   # https://pub.dev/packages/synchronized
   synchronized: ^3.4.0
   # https://pub.dev/packages/device_info_plus
-  device_info_plus: ^12.1.0
+  device_info_plus: ^12.2.0
   # https://pub.dev/packages/package_info_plus
   package_info_plus: ^8.3.1
   # https://pub.dev/packages/clock
@@ -37,11 +37,11 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.7.0
+  build_runner: ^2.10.0
   # https://pub.dev/packages/json_serializable
   json_serializable: ^6.11.1
   # https://pub.dev/packages/mockito
-  mockito: ^5.5.0
+  mockito: ^5.5.1
   # https://pub.dev/packages/path_provider
   path_provider_platform_interface: any
   # https://pub.dev/packages/plugin_platform_interface

--- a/das_client/pubspec.lock
+++ b/das_client/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "88.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.1.1"
   android_id:
     dependency: transitive
     description:
@@ -141,18 +141,18 @@ packages:
     dependency: transitive
     description:
       name: auto_route
-      sha256: c820e918863a03544aac68eaf61e17c8a6126b663d7cad24a8fd3657a1e6be61
+      sha256: "14d4c91a073dd1b1e2678cbea66b3c09c13e5c8111db2d9f3212db9e3cf744b5"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "10.2.0"
   auto_route_generator:
     dependency: transitive
     description:
       name: auto_route_generator
-      sha256: ed4b65e85b4b2b00b06ef1e44c8623985c52c32d05d72147e3201257aa70a115
+      sha256: "3411b3ad9fda50e8bce5a3494a9e0d7385082438e22721febc9e3af08a35bc11"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.4"
+    version: "10.2.5"
   battery_plus:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "6439a9c71a4e6eca8d9490c1b380a25b02675aa688137dfbe66d2062884a23ac"
+      sha256: dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "4.0.2"
   build_config:
     dependency: transitive
     description:
@@ -201,30 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: "2b21a125d66a86b9511cc3fb6c668c42e9a1185083922bf60e46d483a81a9712"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
   build_runner:
     dependency: transitive
     description:
       name: build_runner
-      sha256: fd3c09f4bbff7fa6e8d8ef688a0b2e8a6384e6483a25af0dac75fef362bcfe6f
+      sha256: "8cd45bdd6217138f4cfbaf6286c93f270ae4b3e2e281e69c904bd00cdf8aa626"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: ab27e46c8aa233e610cf6084ee6d8a22c6f873a0a9929241d8855b7a72978ae7
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
+    version: "2.10.0"
   built_collection:
     dependency: transitive
     description:
@@ -265,14 +249,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
-  cli_config:
-    dependency: transitive
-    description:
-      name: cli_config
-      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   cli_launcher:
     dependency: transitive
     description:
@@ -345,14 +321,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  coverage:
-    dependency: transitive
-    description:
-      name: coverage
-      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.14.1"
   crypto:
     dependency: transitive
     description:
@@ -365,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   dbus:
     dependency: transitive
     description:
@@ -381,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "49413c8ca514dea7633e8def233b25efdf83ec8522955cc2c0e3ad802927e7c6"
+      sha256: dd0e8e02186b2196c7848c9d394a5fd6e5b57a43a546082c5820b1ec72317e33
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "12.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -397,18 +365,18 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "540cf382a3bfa99b76e51514db5b0ebcd81ce3679b7c1c9cb9478ff3735e47a1"
+      sha256: "83290a32ae006a7535c5ecf300722cb77177250d9df4ee2becc5fa8a36095114"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.2"
+    version: "2.29.0"
   drift_dev:
     dependency: transitive
     description:
       name: drift_dev
-      sha256: "4db0eeedc7e8bed117a9f22d867ab7a3a294300fed5c269aac90d0b3545967ca"
+      sha256: "6019f827544e77524ffd5134ae0cb75dfd92ef5ef3e269872af92840c929cd43"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.3"
+    version: "2.29.0"
   drift_flutter:
     dependency: transitive
     description:
@@ -816,10 +784,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: "3d3a04c9dda8ced6b2a48d23aaf98ef5aa32f68f9c62da1b6c6d45bf03aa8164"
+      sha256: ef5cd5f907157eb7aa87d1704504b5a6386d2cbff88a3c2b3344477bab323ee9
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   lints:
     dependency: transitive
     description:
@@ -856,10 +824,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "7edaa77edb2017dd0c05b5e1baa501965903c5d6f314dfc096df36ada5275199"
+      sha256: "485fcfd86916cff975d3309b96efccc43e2581150f6498ea957b4b8889f51939"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.0"
   meta:
     dependency: transitive
     description:
@@ -880,10 +848,10 @@ packages:
     dependency: transitive
     description:
       name: mockito
-      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
+      sha256: "4feb43bc4eb6c03e832f5fcd637d1abb44b98f9cfa245c58e27382f58859f8f6"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.1"
   mqtt_client:
     dependency: transitive
     description:
@@ -916,14 +884,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
-  node_preamble:
-    dependency: transitive
-    description:
-      name: node_preamble
-      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -1268,22 +1228,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
-  shelf_packages_handler:
-    dependency: transitive
-    description:
-      name: shelf_packages_handler
-      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  shelf_static:
-    dependency: transitive
-    description:
-      name: shelf_static
-      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1309,34 +1253,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
+      sha256: "9098ab86015c4f1d8af6486b547b11100e73b193e1899015033cb3e14ad20243"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.7"
-  source_map_stack_trace:
-    dependency: transitive
-    description:
-      name: source_map_stack_trace
-      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  source_maps:
-    dependency: transitive
-    description:
-      name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.13"
+    version: "1.3.8"
   source_span:
     dependency: transitive
     description:
@@ -1373,10 +1301,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "57090342af1ce32bb499aa641f4ecdd2d6231b9403cea537ac059e803cc20d67"
+      sha256: "54eea43e36dd3769274c3108625f9ea1a382f8d2ac8b16f3e4589d9bd9b0e16c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.2"
+    version: "0.42.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1433,14 +1361,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  test:
-    dependency: transitive
-    description:
-      name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
@@ -1449,22 +1369,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
-  test_core:
-    dependency: transitive
-    description:
-      name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.11"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1593,14 +1497,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   webview_flutter:
     dependency: transitive
     description:

--- a/das_client/pubspec.yaml
+++ b/das_client/pubspec.yaml
@@ -18,7 +18,7 @@ workspace:
   - local_regulations
 
 dev_dependencies:
-  melos: ^7.1.1
+  melos: ^7.2.0
 
 # Melos Configuration
 

--- a/das_client/settings/pubspec.yaml
+++ b/das_client/settings/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # https://pub.dev/packages/json_annotation
   json_annotation: ^4.9.0
   # https://pub.dev/packages/drift
-  drift: ^2.28.2
+  drift: ^2.29.0
   # https://pub.dev/packages/drift_flutter
   drift_flutter: ^0.2.7
   # https://pub.dev/packages/path_provider
@@ -25,10 +25,10 @@ dependencies:
 
 dev_dependencies:
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.7.0
+  build_runner: ^2.10.0
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/json_serializable
   json_serializable: ^6.11.1
   # https://pub.dev/packages/drift_dev
-  drift_dev: ^2.28.3
+  drift_dev: ^2.29.0

--- a/das_client/sfera/pubspec.yaml
+++ b/das_client/sfera/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   # https://pub.dev/packages/iso_duration
   iso_duration: ^0.1.1
   # https://pub.dev/packages/drift
-  drift: ^2.28.2
+  drift: ^2.29.0
   # https://pub.dev/packages/drift_flutter
   drift_flutter: ^0.2.7
   # https://pub.dev/packages/path_provider
@@ -40,10 +40,10 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/mockito
-  mockito: ^5.5.0
+  mockito: ^5.5.1
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.7.0
+  build_runner: ^2.10.0
   # https://pub.dev/packages/drift_dev
-  drift_dev: ^2.28.3
+  drift_dev: ^2.29.0
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0

--- a/das_client/warnapp/pubspec.yaml
+++ b/das_client/warnapp/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.7.0
+  build_runner: ^2.10.0


### PR DESCRIPTION
Only minor updates. Some major updates like `package_info_plus` are blocked by `geolocator`. See [issue #1751](https://github.com/Baseflow/flutter-geolocator/issues/1751).