### PR TITLE
feat: illustration in messages is neutral (#1403)

### DIFF
--- a/das_client/app/lib/pages/journey/journey_screen/header/widgets/battery_status.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/header/widgets/battery_status.dart
@@ -76,6 +76,7 @@ class _BatteryStatusState extends State<BatteryStatus> {
         child: SBBMessage(
           title: context.l10n.w_modal_sheet_battery_status_battery_almost_empty,
           description: context.l10n.w_modal_sheet_battery_status_plug_in_device,
+          illustration: .Display,
         ),
       ),
     );

--- a/das_client/app/lib/pages/journey/journey_screen/header/widgets/connectivity_icon.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/header/widgets/connectivity_icon.dart
@@ -51,7 +51,7 @@ class ConnectivityIcon extends StatelessWidget {
         child: SBBMessage(
           title: context.l10n.w_modal_sheet_disconnected_wifi_message_title,
           description: context.l10n.w_modal_sheet_disconnected_wifi_message_text,
-          illustration: MessageIllustration.Man,
+          illustration: MessageIllustration.Display,
         ),
       ),
     );
@@ -67,7 +67,7 @@ class ConnectivityIcon extends StatelessWidget {
         child: SBBMessage(
           title: context.l10n.w_modal_sheet_disconnected_message_title,
           description: context.l10n.w_modal_sheet_disconnected_message_text,
-          illustration: MessageIllustration.Display,
+          illustration: .Display,
         ),
       ),
     );


### PR DESCRIPTION
With the release of DSM v5, this will need to be adapted again. (Illustrations will be in separate widget `SBBIllustration`).