### PR TITLE
fix: row icon is displayed even if station name too long (#99)

### DIFF
--- a/das_client/app/lib/pages/journey/journey_screen/widgets/table/cells/service_point_information_cell_title.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/widgets/table/cells/service_point_information_cell_title.dart
@@ -38,7 +38,13 @@ class ServicePointInformationCellTitle extends StatelessWidget {
           overflow: .ellipsis,
         );
         if (shortTermChange != null) {
-          textTitle = wrapWithIndicator(textTitle);
+          textTitle = Row(
+            mainAxisSize: .min,
+            children: [
+              Flexible(child: wrapWithIndicator(textTitle)),
+              SizedBox(width: SBBSpacing.medium),
+            ],
+          );
         }
 
         return DefaultTextStyle.merge(


### PR DESCRIPTION
BEFORE
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-03-10 at 16 08 33" src="https://github.com/user-attachments/assets/0e0dfa33-4565-4b69-a480-d041a227870d" />

AFTER
<img width="2360" height="1640" alt="Simulator Screenshot - iPad (A16) - 2026-03-10 at 16 08 11" src="https://github.com/user-attachments/assets/0a7bac28-d4fe-476e-8190-bd4b789e9cdc" />