### PR TITLE
chore: upgrade flutter and dependencies

### DIFF
--- a/das_client/.fvmrc
+++ b/das_client/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.41.5",
+  "flutter": "3.41.7",
   "flavors": {}
 }

--- a/das_client/app/ios/Podfile
+++ b/das_client/app/ios/Podfile
@@ -41,6 +41,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
 
+    # TODO: This currently prevents removing CocoaPods. Need to wait for Geolocator update or migrate away
     # client doesn't need location in background
     if target.name == "geolocator_apple"
       target.build_configurations.each do |config|

--- a/das_client/app/pubspec.yaml
+++ b/das_client/app/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   # https://pub.dev/packages/clock
   clock: ^1.1.2
   # https://pub.dev/packages/device_info_plus
-  device_info_plus: ^12.3.0
+  device_info_plus: ^12.4.0
   # https://pub.dev/packages/extra_hittest_area
   extra_hittest_area: ^1.0.0
   # https://pub.dev/packages/logging
@@ -59,7 +59,7 @@ dependencies:
   rxdart: ^0.28.0
 
   # https://pub.dev/packages/sbb_design_system_mobile
-  sbb_design_system_mobile: ^4.9.0
+  sbb_design_system_mobile: ^4.11.0
   # https://pub.dev/packages/volume_controller
   volume_controller: ^3.4.4
   # https://pub.dev/packages/wakelock_plus
@@ -71,9 +71,9 @@ dependencies:
   # https://pub.dev/packages/uuid
   uuid: ^4.5.3
   # https://pub.dev/packages/package_info_plus
-  package_info_plus: ^9.0.0
+  package_info_plus: ^9.0.1
   # https://pub.dev/packages/shared_preferences
-  shared_preferences: ^2.5.4
+  shared_preferences: ^2.5.5
   # https://pub.dev/packages/webview_flutter
   webview_flutter: ^4.13.1
   # https://pub.dev/packages/skeletonizer
@@ -94,13 +94,13 @@ dev_dependencies:
   # https://pub.dev/packages/auto_route_generator
   auto_route_generator: ^10.5.0
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_launcher_icons
   flutter_launcher_icons: ^0.14.4
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/fake_async
   fake_async: ^1.3.3
   # https://pub.dev/packages/flutter_prunekit

--- a/das_client/app_links_x/pubspec.yaml
+++ b/das_client/app_links_x/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
 
 
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/flutter_prunekit
@@ -31,5 +31,5 @@ dev_dependencies:
   # https://pub.dev/packages/json_serializable
   json_serializable: ^6.13.1
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
 

--- a/das_client/auth/pubspec.yaml
+++ b/das_client/auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   # https://pub.dev/packages/meta
   meta: ^1.17.0
   # https://pub.dev/packages/sbb_oidc
-  sbb_oidc: ^4.4.0
+  sbb_oidc: ^4.5.0
   # https://pub.dev/packages/collection
   collection: ^1.19.1
   # https://pub.dev/packages/logging
@@ -24,8 +24,8 @@ dev_dependencies:
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_prunekit
   # flutter_prunekit: ^2.4.0 TODO: add back when analyzer >=10.0.0 is supported

--- a/das_client/connectivity_x/pubspec.yaml
+++ b/das_client/connectivity_x/pubspec.yaml
@@ -9,7 +9,7 @@ resolution: workspace
 
 dependencies:
   # https://pub.dev/packages/logging
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^7.1.1
   # https://pub.dev/packages/logging
   logging: ^1.3.0
   # https://pub.dev/packages/rxdart

--- a/das_client/formation/pubspec.yaml
+++ b/das_client/formation/pubspec.yaml
@@ -31,9 +31,9 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/json_serializable

--- a/das_client/logger/pubspec.yaml
+++ b/das_client/logger/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
   # https://pub.dev/packages/path_provider
   path_provider: ^2.1.5
   # https://pub.dev/packages/synchronized
-  synchronized: ^3.4.0
+  synchronized: ^3.4.0+1
   # https://pub.dev/packages/device_info_plus
-  device_info_plus: ^12.3.0
+  device_info_plus: ^12.4.0
   # https://pub.dev/packages/package_info_plus
-  package_info_plus: ^9.0.0
+  package_info_plus: ^9.0.1
   # https://pub.dev/packages/clock
   clock: ^1.1.2
   # https://pub.dev/packages/path
@@ -37,11 +37,11 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/json_serializable
   json_serializable: ^6.13.1
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/path_provider
   path_provider_platform_interface: any
   # https://pub.dev/packages/plugin_platform_interface

--- a/das_client/mqtt/pubspec.yaml
+++ b/das_client/mqtt/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   connectivity_x: 1.0.0
 
   # https://pub.dev/packages/mqtt_client
-  mqtt_client: ^10.11.9
+  mqtt_client: ^10.11.11
   # https://pub.dev/packages/logging
   logging: ^1.3.0
   # https://pub.dev/packages/rxdart

--- a/das_client/preload/pubspec.yaml
+++ b/das_client/preload/pubspec.yaml
@@ -42,7 +42,7 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/flutter_prunekit
@@ -50,6 +50,6 @@ dev_dependencies:
   # https://pub.dev/packages/drift_dev
   drift_dev: ^2.32.1
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/fake_async
   fake_async: ^1.3.3

--- a/das_client/pubspec.lock
+++ b/das_client/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "4425a87d87d0d1303540f867994303f5b141ad2f6ecac7ac2cf8851f41c0cef1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.14.0"
   built_collection:
     dependency: transitive
     description:
@@ -349,18 +349,18 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -405,10 +405,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "4df8babf73058181227e18b08e6ea3520cf5fc5d796888d33b7cb0f33f984b7c"
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "12.3.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -506,18 +506,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_appauth
-      sha256: aba94ecd7aa542240c54c6bb0a875a577c73e9460c199dc74fe58e89e7a98a1a
+      sha256: "93f2991422eab5c84c697c694ec2b2351447ad70c18a68ab3cb364ef6422ebe4"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "12.0.0"
   flutter_appauth_platform_interface:
     dependency: transitive
     description:
       name: flutter_appauth_platform_interface
-      sha256: "6c3c2f3a0060a2bf34880ca75b997b675f148275659c6abe2ff15d0819861259"
+      sha256: a17fe4cd6afa30b634e21922c02657e41130bceb03952a43fa469b95a758c328
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.0"
+    version: "12.0.0"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -548,50 +548,50 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.0.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.0"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.0"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_svg:
     dependency: transitive
     description:
@@ -820,14 +820,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -885,7 +877,7 @@ packages:
     source: hosted
     version: "6.0.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
@@ -912,10 +904,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: e3379a08af92a719a76d4cce9644c98dc87554e0fa3f2a93eb9a04bb295d4a03
+      sha256: "2f7381d209ab7554203c51481a6a57c7896593b7f06190a06a467aa5bfd693c5"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.1"
+    version: "7.5.1"
   meta:
     dependency: transitive
     description:
@@ -936,18 +928,18 @@ packages:
     dependency: transitive
     description:
       name: mockito
-      sha256: a45d1aa065b796922db7b9e7e7e45f921aed17adf3a8318a1f47097e7e695566
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.3"
+    version: "5.6.4"
   mqtt_client:
     dependency: transitive
     description:
       name: mqtt_client
-      sha256: fd22ea00a4c7b5623e01000a91a256d62a8bacba38e9812170458070c52affed
+      sha256: "41c8edd3bc8efc80c1c8ebfb40081c24d12d13085faca96b9280a624eca2d893"
       url: "https://pub.dev"
     source: hosted
-    version: "10.11.9"
+    version: "10.11.11"
   mustache_template:
     dependency: transitive
     description:
@@ -1000,10 +992,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1184,18 +1176,18 @@ packages:
     dependency: transitive
     description:
       name: sbb_design_system_mobile
-      sha256: "145b211b2be170eda4211e0c8fadc9c6ae3daab2e2c700c128a1b5cc5f447fba"
+      sha256: c8c4f74e24b454aea1e32c5f5e0aa5ebf28155c29e14dff31bcbbb46051713fe
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.11.0"
   sbb_oidc:
     dependency: transitive
     description:
       name: sbb_oidc
-      sha256: "314faf619e5b352c033d387b57ee4ccdf09da55919f5d0654bf1ad25cce87e85"
+      sha256: "79fbeae2b0728adaa6a0cea7968483c30e40d4395e332aa365ee493b62b8657a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.5.0"
   screen_brightness:
     dependency: transitive
     description:
@@ -1272,10 +1264,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1453,10 +1445,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1754,5 +1746,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.11.3 <4.0.0"
+  dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.38.1"

--- a/das_client/pubspec.yaml
+++ b/das_client/pubspec.yaml
@@ -8,12 +8,14 @@ environment:
 workspace:
   - "*"
 
-# https://pub.dev/packages/melos
+dependencies:
+  logging: ^1.3.0
+
 dev_dependencies:
-  melos: ^7.4.1
+  # https://pub.dev/packages/melos
+  melos: ^7.5.1
 
 # Melos Configuration
-
 melos:
   scripts:
     clean:das:

--- a/das_client/settings/pubspec.yaml
+++ b/das_client/settings/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
 dev_dependencies:
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_lints
   flutter_lints: ^6.0.0
   # https://pub.dev/packages/json_serializable

--- a/das_client/sfera/pubspec.yaml
+++ b/das_client/sfera/pubspec.yaml
@@ -43,9 +43,9 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/mockito
-  mockito: ^5.6.3
+  mockito: ^5.6.4
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.13.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/drift_dev
   drift_dev: ^2.32.1
   # https://pub.dev/packages/flutter_lints

--- a/das_client/warnapp/pubspec.yaml
+++ b/das_client/warnapp/pubspec.yaml
@@ -27,6 +27,6 @@ dev_dependencies:
     sdk: flutter
 
   # https://pub.dev/packages/build_runner
-  build_runner: ^2.11.1
+  build_runner: ^2.14.0
   # https://pub.dev/packages/flutter_prunekit
   # flutter_prunekit: ^2.4.0 TODO: add back when analyzer >=10.0.0 is supported


### PR DESCRIPTION
Wie besprochen, verhindert `Geolocator` aktuell Upgrade von gewissen Dependencies und die Migration weg von CocoaPods 😢 