### PR TITLE
fix: handle DI Exceptions (#2037)

### DIFF
--- a/das_client/app/lib/nav/app_expiration_guard.dart
+++ b/das_client/app/lib/nav/app_expiration_guard.dart
@@ -9,7 +9,13 @@ final _log = Logger('AppExpirationGuard');
 class AppExpirationGuard extends AutoRouteGuard {
   @override
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
-    final appExpirationVM = DI.get<AppExpirationViewModel>();
+    final appExpirationVM = DI.getOrNull<AppExpirationViewModel>();
+    if (appExpirationVM == null) {
+      _log.warning('AppExpirationViewModel not found in DI. Navigating to ${resolver.route} without expiration check.');
+      resolver.next(true);
+      return;
+    }
+
     try {
       await appExpirationVM.checkIsAppExpired().timeout(
         const Duration(seconds: 1),


### PR DESCRIPTION
Das meiste wurde wohl schon mit den JourneyScope refactoring behoben, da die logs der letzten 30 diesen Fehler nicht mehr zeigen.

Aktuell gibt es auf DEV einige von unseren Testgeräten, dafür scheint aber der Hot Reload verantwortlich zu sein. Das war der einzige Weg wie ich es aktuell reproduzieren konnte. Auf Int gibt es nur noch den einen welcher hier gefixt wird.