### PR TITLE
fix: station sign layout with bracket station

### DIFF
--- a/das_client/app/lib/pages/journey/journey_screen/widgets/table/service_point_row.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/widgets/table/service_point_row.dart
@@ -208,8 +208,7 @@ class ServicePointRow extends CellRowBuilder<ServicePoint> {
         padding: .symmetric(vertical: SBBSpacing.xSmall, horizontal: 2),
         child: Padding(
           padding: config.bracketStationRenderData != null ? const .only(right: SBBSpacing.large) : .zero,
-          child: Row(
-            mainAxisSize: .min,
+          child: Wrap(
             spacing: 2,
             children: [
               if (data.stationSign2 != null)


### PR DESCRIPTION
from 
<img width="708" height="220" alt="image" src="https://github.com/user-attachments/assets/decf6342-c79b-47fa-b8dd-28bf63163ae2" />

to 
<img width="595" height="145" alt="image" src="https://github.com/user-attachments/assets/7d9529f1-e40d-46a0-9f45-b43ee3ff739f" />
