### PR TITLE
fix(dialog): added close-button (#246)

### DIFF
--- a/das_admin_tool/src/app/shared/base-dialog/base-dialog.component.css
+++ b/das_admin_tool/src/app/shared/base-dialog/base-dialog.component.css
@@ -1,3 +1,7 @@
-sbb-dialog-content {
-  padding-block-start: var(--sbb-spacing-fixed-1x);
+:host {
+  display: contents;
+
+  sbb-dialog-content {
+    padding-block-start: var(--sbb-spacing-fixed-1x);
+  }
 }

--- a/das_admin_tool/src/app/shared/base-dialog/base-dialog.component.html
+++ b/das_admin_tool/src/app/shared/base-dialog/base-dialog.component.html
@@ -1,4 +1,5 @@
 <sbb-dialog-title>{{ dialogTitle() }}</sbb-dialog-title>
+<sbb-dialog-close-button></sbb-dialog-close-button>
 <sbb-dialog-content>
   @if (isEdit()) {
     <sbb-stepper (stepchange)="stepchange.set($event)" linear>


### PR DESCRIPTION
Der Close-Button ging [hier](https://github.com/SchweizerischeBundesbahnen/DAS/pull/2205) verloren.
Durch das hinzufügen, wird auch direkt [dieses Problem](https://github.com/SchweizerischeBundesbahnen/DAS/issues/246#issuecomment-4790298059) gelöst.

`display: contents;` damit das CSS-Grid vom Dialog korrekt funktioniert.