### PR TITLE
feat: add animation to notifications (#1880)

### DIFF
--- a/das_client/app/lib/pages/journey/journey_screen/notification/notification_space.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/notification_space.dart
@@ -15,7 +15,9 @@ import 'package:app/pages/journey/journey_screen/view_model/ux_testing_view_mode
 import 'package:app/pages/journey/journey_screen/widgets/warn_function_modal_sheet.dart';
 import 'package:app/pages/journey/view_model/warn_app_view_model.dart';
 import 'package:app/sound/das_sounds.dart';
+import 'package:app/util/animation.dart';
 import 'package:app/widgets/stream_listener.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -44,14 +46,16 @@ class NotificationSpace extends StatelessWidget {
           initialData: notificationPriorityVM.modelValue,
           builder: (context, asyncSnapshot) {
             final data = asyncSnapshot.requireData;
-            if (data.isEmpty) return SizedBox(height: SBBSpacing.xSmall);
 
             return Padding(
-              padding: EdgeInsets.symmetric(horizontal: JourneyOverview.horizontalPadding, vertical: SBBSpacing.xSmall),
+              padding: EdgeInsets.symmetric(horizontal: JourneyOverview.horizontalPadding),
               child: Column(
                 mainAxisSize: .min,
-                spacing: SBBSpacing.xSmall,
-                children: data.map((notification) => notification.toWidget()).toList(growable: false),
+                children: [
+                  const SizedBox(height: SBBSpacing.xSmall),
+                  _AnimatedNotificationSlot(type: data.elementAtOrNull(0)),
+                  _AnimatedNotificationSlot(type: data.elementAtOrNull(1)),
+                ],
               ),
             );
           },
@@ -68,6 +72,42 @@ class NotificationSpace extends StatelessWidget {
         onManeuverButtonPressed: () => context.read<WarnAppViewModel>().setManeuverMode(true),
       );
     });
+  }
+}
+
+/// Animates the notification of a single slot in [NotificationSpace].
+///
+/// Appearing ([type] set) fades and grows the notification in, disappearing ([type] null) fades and
+/// collapses it. Replacing one notification with another cross-fades while the size transitions
+/// directly between the two heights, keeping the occupied space instead of collapsing it.
+class _AnimatedNotificationSlot extends StatelessWidget {
+  const _AnimatedNotificationSlot({required this.type});
+
+  final NotificationType? type;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSize(
+      duration: DASAnimation.mediumDuration,
+      curve: Curves.easeInOutCubicEmphasized,
+      alignment: Alignment.topCenter,
+      child: AnimatedSwitcher(
+        duration: DASAnimation.mediumDuration,
+        switchInCurve: Curves.easeInOutCubicEmphasized,
+        switchOutCurve: Curves.easeInOutCubicEmphasized,
+        layoutBuilder: (currentChild, previousChildren) => Stack(
+          alignment: Alignment.topCenter,
+          children: [...previousChildren, ?currentChild],
+        ),
+        child: type == null
+            ? const SizedBox(key: ValueKey('emptyNotificationSlot'), width: double.infinity)
+            : Padding(
+                key: ValueKey(type),
+                padding: const EdgeInsets.only(bottom: SBBSpacing.xSmall),
+                child: type!.toWidget(),
+              ),
+      ),
+    );
   }
 }
 

--- a/das_client/app/lib/pages/journey/journey_screen/notification/notification_space.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/notification_space.dart
@@ -2,6 +2,7 @@ import 'package:app/di/di.dart';
 import 'package:app/pages/journey/journey_screen/journey_overview.dart';
 import 'package:app/pages/journey/journey_screen/notification/notification_type.dart';
 import 'package:app/pages/journey/journey_screen/notification/widgets/advised_speed_notification.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/notification/widgets/brake_load_slip_notification.dart';
 import 'package:app/pages/journey/journey_screen/notification/widgets/customer_oriented_departure_notification.dart';
 import 'package:app/pages/journey/journey_screen/notification/widgets/departure_dispatch_notification.dart';
@@ -15,9 +16,7 @@ import 'package:app/pages/journey/journey_screen/view_model/ux_testing_view_mode
 import 'package:app/pages/journey/journey_screen/widgets/warn_function_modal_sheet.dart';
 import 'package:app/pages/journey/view_model/warn_app_view_model.dart';
 import 'package:app/sound/das_sounds.dart';
-import 'package:app/util/animation.dart';
 import 'package:app/widgets/stream_listener.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -53,8 +52,18 @@ class NotificationSpace extends StatelessWidget {
                 mainAxisSize: .min,
                 children: [
                   const SizedBox(height: SBBSpacing.xSmall),
-                  _AnimatedNotificationSlot(type: data.elementAtOrNull(0)),
-                  _AnimatedNotificationSlot(type: data.elementAtOrNull(1)),
+                  // one slot per type in priority order: showing or hiding a notification resizes its
+                  // slot, so the other notifications slide to their new position
+                  for (final type in NotificationType.values)
+                    AnimatedNotificationVisibility(
+                      visible: data.contains(type),
+                      child: data.contains(type)
+                          ? Padding(
+                              padding: const EdgeInsets.only(bottom: SBBSpacing.xSmall),
+                              child: type.toWidget(),
+                            )
+                          : const SizedBox.shrink(),
+                    ),
                 ],
               ),
             );
@@ -72,42 +81,6 @@ class NotificationSpace extends StatelessWidget {
         onManeuverButtonPressed: () => context.read<WarnAppViewModel>().setManeuverMode(true),
       );
     });
-  }
-}
-
-/// Animates the notification of a single slot in [NotificationSpace].
-///
-/// Appearing ([type] set) fades and grows the notification in, disappearing ([type] null) fades and
-/// collapses it. Replacing one notification with another cross-fades while the size transitions
-/// directly between the two heights, keeping the occupied space instead of collapsing it.
-class _AnimatedNotificationSlot extends StatelessWidget {
-  const _AnimatedNotificationSlot({required this.type});
-
-  final NotificationType? type;
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedSize(
-      duration: DASAnimation.mediumDuration,
-      curve: Curves.easeInOutCubicEmphasized,
-      alignment: Alignment.topCenter,
-      child: AnimatedSwitcher(
-        duration: DASAnimation.mediumDuration,
-        switchInCurve: Curves.easeInOutCubicEmphasized,
-        switchOutCurve: Curves.easeInOutCubicEmphasized,
-        layoutBuilder: (currentChild, previousChildren) => Stack(
-          alignment: Alignment.topCenter,
-          children: [...previousChildren, ?currentChild],
-        ),
-        child: type == null
-            ? const SizedBox(key: ValueKey('emptyNotificationSlot'), width: double.infinity)
-            : Padding(
-                key: ValueKey(type),
-                padding: const EdgeInsets.only(bottom: SBBSpacing.xSmall),
-                child: type!.toWidget(),
-              ),
-      ),
-    );
   }
 }
 

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/advised_speed_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/advised_speed_notification.dart
@@ -1,6 +1,7 @@
 import 'package:app/extension/single_speed_extension.dart';
 import 'package:app/i18n/i18n.dart';
 import 'package:app/pages/journey/journey_screen/notification/widgets/advised_speed_notification_hints.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/view_model/advised_speed_view_model.dart';
 import 'package:app/pages/journey/journey_screen/view_model/model/advised_speed_model.dart';
 import 'package:app/theme/das_colors.dart';
@@ -23,18 +24,14 @@ class AdvisedSpeedNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<AdvisedSpeedViewModel>();
 
-    return StreamBuilder<AdvisedSpeedModel>(
+    return AnimatedNotification<AdvisedSpeedModel>(
       stream: viewModel.model,
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) return SizedBox.shrink();
-
-        final model = snapshot.requireData;
-        return switch (model) {
-          Active() => _activeSegmentNotification(context, model),
-          End() => _notificationBar(context, context.l10n.w_advised_speed_end),
-          Cancel() => _notificationBar(context, context.l10n.w_advised_speed_cancel),
-          Inactive() => SizedBox.shrink(),
-        };
+      isVisible: (model) => model != null && model is! Inactive,
+      builder: (context, model) => switch (model) {
+        Active() => _activeSegmentNotification(context, model),
+        End() => _notificationBar(context, context.l10n.w_advised_speed_end),
+        Cancel() => _notificationBar(context, context.l10n.w_advised_speed_cancel),
+        Inactive() || null => SizedBox.shrink(),
       },
     );
   }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
@@ -37,9 +37,6 @@ class AnimatedNotification<T> extends StatelessWidget {
 }
 
 /// Animates between a visible notification [child] and an empty box with a fade and size transition.
-///
-/// While hiding, the previously visible child keeps being rendered and animates out instead of
-/// being replaced by an empty box immediately.
 class AnimatedNotificationVisibility extends StatelessWidget {
   const AnimatedNotificationVisibility({
     required this.visible,
@@ -49,7 +46,6 @@ class AnimatedNotificationVisibility extends StatelessWidget {
 
   final bool visible;
 
-  /// The notification content, only rendered while [visible] or animating out.
   final Widget child;
 
   @override

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
@@ -27,19 +27,48 @@ class AnimatedNotification<T> extends StatelessWidget {
       builder: (context, snapshot) {
         final data = snapshot.data;
         final visible = isVisible(data);
-        return AnimatedSwitcher(
-          duration: DASAnimation.mediumDuration,
-          switchInCurve: Curves.easeInOutCubicEmphasized,
-          switchOutCurve: Curves.easeInOutCubicEmphasized,
-          transitionBuilder: (child, animation) => FadeTransition(
-            opacity: animation,
-            child: SizeTransition(sizeFactor: animation, alignment: Alignment.topCenter, child: child),
-          ),
-          child: visible
-              ? KeyedSubtree(key: const ValueKey('animatedNotificationVisible'), child: builder(context, data))
-              : const SizedBox(key: ValueKey('animatedNotificationHidden'), width: double.infinity),
+        return AnimatedNotificationVisibility(
+          visible: visible,
+          child: visible ? builder(context, data) : const SizedBox.shrink(),
         );
       },
+    );
+  }
+}
+
+/// Animates between a visible notification [child] and an empty box with a fade and size transition.
+///
+/// While hiding, the previously visible child keeps being rendered and animates out instead of
+/// being replaced by an empty box immediately.
+class AnimatedNotificationVisibility extends StatelessWidget {
+  const AnimatedNotificationVisibility({
+    required this.visible,
+    required this.child,
+    super.key,
+  });
+
+  final bool visible;
+
+  /// The notification content, only rendered while [visible] or animating out.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: DASAnimation.mediumDuration,
+      switchInCurve: Curves.easeInOutCubicEmphasized,
+      switchOutCurve: Curves.easeInOutCubicEmphasized,
+      transitionBuilder: (child, animation) => FadeTransition(
+        opacity: animation,
+        child: SizeTransition(sizeFactor: animation, alignment: Alignment.topCenter, child: child),
+      ),
+      layoutBuilder: (currentChild, previousChildren) => Stack(
+        alignment: Alignment.topCenter,
+        children: [...previousChildren, ?currentChild],
+      ),
+      child: visible
+          ? KeyedSubtree(key: const ValueKey('animatedNotificationVisible'), child: child)
+          : const SizedBox(key: ValueKey('animatedNotificationHidden'), width: double.infinity),
     );
   }
 }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/animated_notification.dart
@@ -1,0 +1,45 @@
+import 'package:app/util/animation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Animates the show and hide (fade and size transition) of a notification driven by [stream].
+class AnimatedNotification<T> extends StatelessWidget {
+  const AnimatedNotification({
+    required this.stream,
+    required this.isVisible,
+    required this.builder,
+    this.initialData,
+    super.key,
+  });
+
+  final Stream<T> stream;
+
+  final T? initialData;
+
+  final bool Function(T? data) isVisible;
+
+  final Widget Function(BuildContext context, T? data) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<T>(
+      stream: stream,
+      initialData: initialData,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        final visible = isVisible(data);
+        return AnimatedSwitcher(
+          duration: DASAnimation.mediumDuration,
+          switchInCurve: Curves.easeInOutCubicEmphasized,
+          switchOutCurve: Curves.easeInOutCubicEmphasized,
+          transitionBuilder: (child, animation) => FadeTransition(
+            opacity: animation,
+            child: SizeTransition(sizeFactor: animation, alignment: Alignment.topCenter, child: child),
+          ),
+          child: visible
+              ? KeyedSubtree(key: const ValueKey('animatedNotificationVisible'), child: builder(context, data))
+              : const SizedBox(key: ValueKey('animatedNotificationHidden'), width: double.infinity),
+        );
+      },
+    );
+  }
+}

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/brake_load_slip_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/brake_load_slip_notification.dart
@@ -1,5 +1,6 @@
 import 'package:app/i18n/i18n.dart';
 import 'package:app/pages/journey/brake_load_slip/brake_load_slip_view_model.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sbb_design_system_mobile/sbb_design_system_mobile.dart';
@@ -13,20 +14,16 @@ class BrakeLoadSlipNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<BrakeLoadSlipViewModel>();
 
-    return StreamBuilder(
+    return AnimatedNotification<bool>(
       initialData: viewModel.formationChangedValue,
       stream: viewModel.formationChanged,
-      builder: (context, snapshot) {
-        final isFormationChanged = snapshot.data ?? false;
-        if (!isFormationChanged) return SizedBox.shrink();
-
-        return SBBNotificationBox.information(
-          key: brakeLoadSlipNotificationKey,
-          contentText: context.l10n.w_brake_load_slip_notification_text,
-          onTap: () => viewModel.open(context),
-          isDismissable: false,
-        );
-      },
+      isVisible: (isFormationChanged) => isFormationChanged ?? false,
+      builder: (context, _) => SBBNotificationBox.information(
+        key: brakeLoadSlipNotificationKey,
+        contentText: context.l10n.w_brake_load_slip_notification_text,
+        onTap: () => viewModel.open(context),
+        isDismissable: false,
+      ),
     );
   }
 }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/customer_oriented_departure_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/customer_oriented_departure_notification.dart
@@ -1,4 +1,5 @@
 import 'package:app/i18n/i18n.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/view_model/customer_oriented_departure_view_model.dart';
 import 'package:app/pages/journey/journey_screen/view_model/ux_testing_view_model.dart';
 import 'package:app/pages/journey/journey_screen/widgets/departure_process_dialog.dart';
@@ -20,17 +21,14 @@ class CustomerOrientedDepartureNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<CustomerOrientedDepartureViewModel>();
 
-    return StreamBuilder<CustomerOrientedDepartureStatus>(
+    return AnimatedNotification<CustomerOrientedDepartureStatus>(
       stream: viewModel.status,
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) return SizedBox.shrink();
-
-        return switch (snapshot.data!) {
-          .wait => _WaitNotification(displayDepartureProcessButton: displayDepartureProcessButton),
-          .ready => _ReadyNotification(displayDepartureProcessButton: displayDepartureProcessButton),
-          .call => _CallNotification(displayDepartureProcessButton: displayDepartureProcessButton),
-          .departure => SizedBox.shrink(),
-        };
+      isVisible: (status) => status != null && status != .departure,
+      builder: (context, status) => switch (status) {
+        .wait => _WaitNotification(displayDepartureProcessButton: displayDepartureProcessButton),
+        .ready => _ReadyNotification(displayDepartureProcessButton: displayDepartureProcessButton),
+        .call => _CallNotification(displayDepartureProcessButton: displayDepartureProcessButton),
+        .departure || null => SizedBox.shrink(),
       },
     );
   }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/departure_dispatch_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/departure_dispatch_notification.dart
@@ -1,4 +1,5 @@
 import 'package:app/i18n/i18n.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/view_model/departure_dispatch_notification_view_model.dart';
 import 'package:app/theme/theme_util.dart';
 import 'package:flutter/material.dart';
@@ -15,13 +16,10 @@ class DepartureDispatchNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<DepartureDispatchNotificationViewModel>();
 
-    return StreamBuilder(
+    return AnimatedNotification<DepartureDispatchNotificationType?>(
       stream: viewModel.type,
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) return SizedBox.shrink();
-
-        return _notification(context, type: snapshot.data!);
-      },
+      isVisible: (type) => type != null,
+      builder: (context, type) => _notification(context, type: type!),
     );
   }
 

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/disturbance_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/disturbance_notification.dart
@@ -1,4 +1,5 @@
 import 'package:app/i18n/i18n.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/view_model/disturbance_view_model.dart';
 import 'package:app/widgets/notificationbox/notification_box.dart';
 import 'package:flutter/material.dart';
@@ -15,19 +16,15 @@ class DisturbanceNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<DisturbanceViewModel>();
 
-    return StreamBuilder(
+    return AnimatedNotification<DisturbanceEventType?>(
       stream: viewModel.disturbanceStream,
-      builder: (context, snapshot) {
-        final disturbanceType = snapshot.data ?? false;
-        if (disturbanceType != DisturbanceEventType.start) return SizedBox.shrink();
-
-        return NotificationBox(
-          style: .warning,
-          title: context.l10n.w_disturbance_notification_text,
-          customIcon: SBBIcons.arrow_circle_lightning_small,
-          key: disturbanceNotificationKey,
-        );
-      },
+      isVisible: (disturbanceType) => disturbanceType == DisturbanceEventType.start,
+      builder: (context, _) => NotificationBox(
+        style: .warning,
+        title: context.l10n.w_disturbance_notification_text,
+        customIcon: SBBIcons.arrow_circle_lightning_small,
+        key: disturbanceNotificationKey,
+      ),
     );
   }
 }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/maneuver_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/maneuver_notification.dart
@@ -1,4 +1,5 @@
 import 'package:app/i18n/i18n.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/view_model/warn_app_view_model.dart';
 import 'package:app/widgets/das_icons.dart';
 import 'package:app/widgets/notificationbox/notification_box.dart';
@@ -16,29 +17,25 @@ class ManeuverNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<WarnAppViewModel>();
 
-    return StreamBuilder(
+    return AnimatedNotification<bool>(
       stream: viewModel.isManeuverModeEnabled,
-      builder: (context, snapshot) {
-        final isManeuverModeEnabled = snapshot.data ?? false;
-        if (!isManeuverModeEnabled) return SizedBox.shrink();
-
-        return NotificationBox(
-          style: .warning,
-          title: context.l10n.w_maneuver_notification_text,
-          action: Row(
-            children: [
-              _openWaraButton(viewModel),
-              Text(context.l10n.w_maneuver_notification_maneuver, style: sbbTextStyle.lightStyle.medium),
-              const SizedBox(width: SBBSpacing.xSmall),
-              SBBSwitch(
-                key: maneuverNotificationSwitchKey,
-                value: isManeuverModeEnabled,
-                onChanged: (value) => viewModel.setManeuverMode(value),
-              ),
-            ],
-          ),
-        );
-      },
+      isVisible: (isManeuverModeEnabled) => isManeuverModeEnabled ?? false,
+      builder: (context, isManeuverModeEnabled) => NotificationBox(
+        style: .warning,
+        title: context.l10n.w_maneuver_notification_text,
+        action: Row(
+          children: [
+            _openWaraButton(viewModel),
+            Text(context.l10n.w_maneuver_notification_maneuver, style: sbbTextStyle.lightStyle.medium),
+            const SizedBox(width: SBBSpacing.xSmall),
+            SBBSwitch(
+              key: maneuverNotificationSwitchKey,
+              value: isManeuverModeEnabled ?? false,
+              onChanged: (value) => viewModel.setManeuverMode(value),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/replacement_series_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/replacement_series_notification.dart
@@ -1,4 +1,5 @@
 import 'package:app/i18n/i18n.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/view_model/model/replacement_series_model.dart';
 import 'package:app/pages/journey/journey_screen/view_model/replacement_series_view_model.dart';
 import 'package:app/widgets/notificationbox/notification_box.dart';
@@ -16,26 +17,18 @@ class ReplacementSeriesNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<ReplacementSeriesViewModel>();
 
-    return StreamBuilder<ReplacementSeriesModel?>(
+    return AnimatedNotification<ReplacementSeriesModel?>(
       stream: viewModel.model,
       initialData: viewModel.modelValue,
-      builder: (context, snapshot) {
-        return switch (snapshot.data) {
-          ReplacementSeriesAvailable() => _replacementSeriesAvailableNotification(
-            context,
-            snapshot.data as ReplacementSeriesAvailable,
-          ),
-          OriginalSeriesAvailable() => _replacementSeriesOriginalNotification(
-            context,
-            snapshot.data as OriginalSeriesAvailable,
-          ),
-          NoReplacementSeries() => _noReplacementSeriesAvailableNotification(
-            context,
-            snapshot.data as NoReplacementSeries,
-          ),
-          ReplacementSeriesSelected() => SizedBox.shrink(),
-          null => SizedBox.shrink(),
-        };
+      isVisible: (model) => switch (model) {
+        ReplacementSeriesAvailable() || OriginalSeriesAvailable() || NoReplacementSeries() => true,
+        ReplacementSeriesSelected() || null => false,
+      },
+      builder: (context, model) => switch (model) {
+        ReplacementSeriesAvailable() => _replacementSeriesAvailableNotification(context, model),
+        OriginalSeriesAvailable() => _replacementSeriesOriginalNotification(context, model),
+        NoReplacementSeries() => _noReplacementSeriesAvailableNotification(context, model),
+        ReplacementSeriesSelected() || null => SizedBox.shrink(),
       },
     );
   }

--- a/das_client/app/lib/pages/journey/journey_screen/notification/widgets/suspicious_segment_notification.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/notification/widgets/suspicious_segment_notification.dart
@@ -1,5 +1,6 @@
 import 'package:app/i18n/i18n.dart';
 import 'package:app/pages/journey/journey_screen/header/view_model/model/suspicious_segment_model.dart';
+import 'package:app/pages/journey/journey_screen/notification/widgets/animated_notification.dart';
 import 'package:app/pages/journey/journey_screen/header/view_model/suspicious_segment_view_model.dart';
 import 'package:app/widgets/notificationbox/notification_box.dart';
 import 'package:flutter/material.dart';
@@ -16,13 +17,11 @@ class SuspiciousSegmentNotification extends StatelessWidget {
   Widget build(BuildContext context) {
     final viewModel = context.read<SuspiciousSegmentViewModel>();
 
-    return StreamBuilder<SuspiciousSegmentModel>(
+    return AnimatedNotification<SuspiciousSegmentModel>(
       stream: viewModel.model,
       initialData: viewModel.modelValue,
-      builder: (context, snapshot) {
-        final model = snapshot.data;
-        if (model is! SuspiciousSegmentVisible) return SizedBox.shrink();
-
+      isVisible: (model) => model is SuspiciousSegmentVisible,
+      builder: (context, model) {
         return NotificationBox(
           key: suspiciousSegmentNotificationKey,
           style: .warning,

--- a/sfera_mock/src/main/resources/static_sfera_resources/T38_notification_prioritization/SFERA_TC_T38_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T38_notification_prioritization/SFERA_TC_T38_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TrainCharacteristics xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:noNamespaceSchemaLocation="../../SFERA.xsd" TC_ID="T33_1" TC_VersionMajor="1"
+                      xsi:noNamespaceSchemaLocation="../../SFERA.xsd" TC_ID="T38_1" TC_VersionMajor="1"
                       TC_VersionMinor="0">
     <TC_RU_ID>1285</TC_RU_ID>
     <TC_Features trainCategoryCode="R" brakedWeightPercentage="150"/>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_12000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_12000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overlad"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_15000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_15000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overload_end"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_18000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_18000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overlad"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_21000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_21000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="waitHide"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_24000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_24000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overload_end"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_27000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_27000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overlad"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_3000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_3000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="wait"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_30000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_30000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="wait"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_33000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_33000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="waitHide"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_36000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_36000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overload_end"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_39000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_39000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overlad"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_42000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_42000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>ddMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="message" value="PREPARE_FOR_DEPARTURE_LONG"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_45000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_45000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="wait"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_48000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_48000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="waitHide"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_51000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_51000.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T48</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2025-11-13</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T48_1" location="100">
+                    <SP_Zone>
+                        <IM_ID>1285</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0M00S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_54000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_54000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>lmlcMsg</NSP_GroupName>
+        <NetworkSpecificParameter name="disturbanceMsg" value="grid_power_overload_end"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_6000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_6000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="waitHide"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_9000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_Event_T48_9000.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <NetworkSpecificEvent>
+        <teltsi_Company>1285</teltsi_Company>
+        <NSP_GroupName>uxTesting</NSP_GroupName>
+        <NetworkSpecificParameter name="koa" value="wait"/>
+    </NetworkSpecificEvent>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_JP_T48.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_JP_T48.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="../../SFERA.xsd"
+                JP_Version="1" JP_Status="Valid">
+    <TrainIdentification>
+        <OTN_ID>
+            <teltsi_Company>1285</teltsi_Company>
+            <teltsi_OperationalTrainNumber>T48</teltsi_OperationalTrainNumber>
+            <teltsi_StartDate>2025-11-13</teltsi_StartDate>
+        </OTN_ID>
+    </TrainIdentification>
+    <SegmentProfileReference SP_ID="T48_1" SP_VersionMajor="1" SP_VersionMinor="0" SP_Direction="Nominal">
+        <SP_Zone>
+            <IM_ID>1285</IM_ID>
+        </SP_Zone>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="ABC"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="DEF"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TrainCharacteristicsRef TC_ID="T48_1" TC_VersionMajor="1" TC_VersionMinor="0" location="0">
+            <TC_RU_ID>1285</TC_RU_ID>
+        </TrainCharacteristicsRef>
+    </SegmentProfileReference>
+</JourneyProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_SP_T48_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_SP_T48_1.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="../../SFERA.xsd" SP_ID="T48_1" SP_VersionMajor="1"
+                SP_VersionMinor="0" SP_Length="400" SP_Status="Valid">
+    <SP_Zone>
+        <IM_ID>1285</IM_ID>
+    </SP_Zone>
+    <SP_Points>
+        <TimingPoint TP_ID="ABC" location="100">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>00100</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <TimingPoint TP_ID="DEF" location="300">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>00300</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+        <Signal>
+            <Signal_ID signal_ID_Physical="A123" location="200"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="A123"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="A234" location="250"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="A234"/>
+        </Signal>
+    </SP_Points>
+    <SP_Areas>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="100" endLocation="100"
+                          TAF_TAP_location_abbreviation="ABC" TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>00100</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>ABC</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="300" endLocation="300"
+                          TAF_TAP_location_abbreviation="DEF" TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>00300</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>DEF</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+    </SP_Areas>
+    <SP_ContextInformation>
+        <KilometreReferencePoint location="100">
+            <KM_Reference kmRef="1"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="200">
+            <KM_Reference kmRef="2"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="250">
+            <KM_Reference kmRef="2"/>
+        </KilometreReferencePoint>
+        <KilometreReferencePoint location="300">
+            <KM_Reference kmRef="3"/>
+        </KilometreReferencePoint>
+    </SP_ContextInformation>
+</SegmentProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_TC_T48_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T48_notification_animations/SFERA_TC_T48_1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrainCharacteristics xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:noNamespaceSchemaLocation="../../SFERA.xsd" TC_ID="T48_1" TC_VersionMajor="1"
+                      TC_VersionMinor="0">
+    <TC_RU_ID>1285</TC_RU_ID>
+    <TC_Features trainCategoryCode="R" brakedWeightPercentage="150"/>
+</TrainCharacteristics>


### PR DESCRIPTION
I will do some profiling before my final favorite one. The commits point to the different versions shown in the videos. All videos are recorded with 5x more animation time.

This always open the T48 (new test journey).

**EDIT**

I profiled the main variant vs. sliding included variant, the results are quite large and cannot be included here (>50MB).

* Both the main and animated switcher had no visible stutter
* the sliding one had one stutter in over 50s runtime

So I guess this is not to decisive.

@EverheardofUX has given her vote to the third option, and I will go with that, so I will revert the branch to that state and create the ready PR.

VIDEOS:

**MAIN (as of today)**

https://github.com/user-attachments/assets/1da4af7d-7023-486f-9ad1-3eda1467e9a4

**Only fade transitions, no sliding (simple Animated Switcher)**

https://github.com/user-attachments/assets/2a839c98-1e4b-4307-8f6b-cd54314e4938

**Sliding included**

https://github.com/user-attachments/assets/3c63fb8b-44fc-4782-b037-d24485c8dfe0


**Sliding improved by using animation intervals**

https://github.com/user-attachments/assets/2a79f288-1967-492c-9195-a99ac645512d




