### PR TITLE
fix: add transaction to saving ru features locally (#2257)

### DIFF
--- a/das_client/settings/lib/src/data/local/settings_database_service.dart
+++ b/das_client/settings/lib/src/data/local/settings_database_service.dart
@@ -40,12 +40,13 @@ class SettingsDatabaseService extends _$SettingsDatabaseService implements RuFea
 
   @override
   Future<void> replaceAllRuFeatures(List<RuFeatureDto> ruFeatures) async {
-    return _ruFeatureTableManager.delete().then(
-      (_) => _ruFeatureTableManager.bulkCreate(
+    return transaction(() async {
+      await _ruFeatureTableManager.delete();
+      await _ruFeatureTableManager.bulkCreate(
         (_) => ruFeatures.map((element) => element.toCompanion()),
-        mode: InsertMode.insertOrFail,
-      ),
-    );
+        mode: .insertOrReplace,
+      );
+    });
   }
 
   $$RuFeaturesTableTableTableManager get _ruFeatureTableManager => managers.ruFeaturesTable;

--- a/das_client/settings/lib/src/repository/settings_repository_impl.dart
+++ b/das_client/settings/lib/src/repository/settings_repository_impl.dart
@@ -25,6 +25,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
   final SettingsLoaded? _onSettingsLoaded;
 
   SettingsDto? _lastSettings;
+  Future<bool>? _pendingLoadSettings;
 
   void _init() async {
     final success = await loadSettings();
@@ -49,7 +50,11 @@ class SettingsRepositoryImpl implements SettingsRepository {
   }
 
   @override
-  Future<bool> loadSettings() async {
+  Future<bool> loadSettings() {
+    return _pendingLoadSettings ??= _loadSettings().whenComplete(() => _pendingLoadSettings = null);
+  }
+
+  Future<bool> _loadSettings() async {
     SettingsDto? remoteSettings;
     try {
       remoteSettings = await _tryFetchSettings();

--- a/das_client/settings/test/src/repository/settings_repository_test.dart
+++ b/das_client/settings/test/src/repository/settings_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fake_async/fake_async.dart';
@@ -254,6 +255,70 @@ void main() {
 
     // EXPECT
     expect(result, isTrue);
+  });
+
+  test('whenLoadSettingsCalledWhileLoadInProgress_sharesRequest', () async {
+    // ARRANGE
+    final results = <bool>[];
+    fakeAsync((fakeAsync) {
+      final completer = Completer<SettingsResponse>();
+      when(mockSettingsRequest.call()).thenAnswer((_) => completer.future);
+      testee = SettingsRepositoryImpl(
+        apiService: apiService,
+        databaseService: settingsDatabaseService,
+        onAwsCredentialsChanged: mockCallbacks.awsCredentialsChanged,
+      );
+      fakeAsync.flushMicrotasks();
+
+      // ACT
+      testee.loadSettings().then(results.add);
+      testee.loadSettings().then(results.add);
+      completer.complete(buildSettingsResponse());
+      fakeAsync.flushMicrotasks();
+    });
+
+    // EXPECT
+    expect(results, [true, true]);
+    verify(apiService.settings).called(1);
+    verify(mockSettingsRequest.call()).called(1);
+  });
+
+  test('whenLoadSettingsCalledWhileLoadInProgressAndFails_allCallersReceiveFalse', () async {
+    // ARRANGE
+    final results = <bool>[];
+    fakeAsync((fakeAsync) {
+      final completer = Completer<SettingsResponse>();
+      when(mockSettingsRequest.call()).thenAnswer((_) => completer.future);
+      testee = SettingsRepositoryImpl(
+        apiService: apiService,
+        databaseService: settingsDatabaseService,
+        onAwsCredentialsChanged: mockCallbacks.awsCredentialsChanged,
+      );
+      fakeAsync.flushMicrotasks();
+
+      // ACT
+      testee.loadSettings().then(results.add);
+      testee.loadSettings().then(results.add);
+      completer.completeError(HttpException('Exception'));
+      fakeAsync.flushMicrotasks();
+    });
+
+    // EXPECT
+    expect(results, [false, false]);
+    verify(apiService.settings).called(1);
+  });
+
+  test('whenLoadSettingsCalledAfterPreviousLoadCompleted_triggersNewRequest', () async {
+    // ARRANGE
+    when(mockSettingsRequest.call()).thenAnswer((_) => Future.value(buildSettingsResponse()));
+
+    // ACT
+    await initTestee();
+    await testee.loadSettings();
+
+    // EXPECT
+    verify(apiService.settings).called(2);
+    verify(mockSettingsRequest.call()).called(2);
   });
 
   test('whenSettingsFetchFails_loadSettingsReturnsFalse', () async {


### PR DESCRIPTION
One call from _init and one call from appExpirationViewModel could cause race condition / concurrency issues. Moved to transaction to avoid and added a pending state to SettingsRepository to not call it twice.