### PR TITLE
fix: avoid poison pill log file for splunk after 4xx (#2578)

### DIFF
--- a/das_client/logger/lib/src/data/api/endpoint/send_logs.dart
+++ b/das_client/logger/lib/src/data/api/endpoint/send_logs.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:http_x/component.dart';
+import 'package:logger/src/data/api/send_logs_exception.dart';
 
 class SendLogsRequest {
   const SendLogsRequest({required this.httpClient, this.url, this.token});
@@ -9,19 +10,27 @@ class SendLogsRequest {
   final String? url;
   final String? token;
 
+  /// Sends the given log file to the remote endpoint.
+  ///
+  /// Throws a [TransientSendLogsException] or [PermanentSendLogsException] on failure.
   Future<SendLogsResponse> call(File logFile) async {
     if (this.url == null || token == null) {
-      return Future.error('logging url or token not configured');
+      throw const TransientSendLogsException('logging url or token not configured');
     }
 
     final logFileContent = logFile.readAsStringSync();
 
     final url = Uri.parse(this.url!);
-    final response = await httpClient.post(
-      url,
-      headers: {'Content-Type': 'application/json', 'Authorization': 'Splunk $token'},
-      body: '[$logFileContent]',
-    );
+    final Response response;
+    try {
+      response = await httpClient.post(
+        url,
+        headers: {'Content-Type': 'application/json', 'Authorization': 'Splunk $token'},
+        body: '[$logFileContent]',
+      );
+    } catch (ex) {
+      throw TransientSendLogsException(ex);
+    }
     return SendLogsResponse.fromHttpResponse(response);
   }
 }
@@ -36,8 +45,19 @@ class SendLogsResponse {
       return SendLogsResponse(headers: response.headers);
     }
     // Failure
-    throw HttpException.fromResponse(response);
+    final exception = HttpException.fromResponse(response);
+    if (_isTransient(status)) throw TransientSendLogsException(exception);
+    throw PermanentSendLogsException(exception);
   }
+
+  /// Server errors may resolve themselves, as may these client errors:
+  /// 401/403 (misconfigured token, logs can be sent once fixed), 408 (request timeout) and 429 (throttling).
+  static bool _isTransient(int statusCode) =>
+      statusCode >= 500 ||
+      statusCode == HttpStatus.unauthorized ||
+      statusCode == HttpStatus.forbidden ||
+      statusCode == HttpStatus.requestTimeout ||
+      statusCode == HttpStatus.tooManyRequests;
 
   final Map<String, String> headers;
 }

--- a/das_client/logger/lib/src/data/api/send_logs_exception.dart
+++ b/das_client/logger/lib/src/data/api/send_logs_exception.dart
@@ -1,0 +1,21 @@
+/// Classifies failures of sending logs to the remote endpoint.
+sealed class SendLogsException implements Exception {
+  const SendLogsException(this.cause);
+
+  /// The underlying failure, e.g. an HttpException or a connection error.
+  final Object cause;
+
+  @override
+  String toString() => '$runtimeType{cause: $cause}';
+}
+
+/// The send failed for a reason that may resolve itself, e.g. missing connectivity,
+/// server errors, throttling or a misconfigured token. Keep the payload and retry later.
+class TransientSendLogsException extends SendLogsException {
+  const TransientSendLogsException(super.cause);
+}
+
+/// The remote rejected the payload. Retrying can never succeed, discard the payload.
+class PermanentSendLogsException extends SendLogsException {
+  const PermanentSendLogsException(super.cause);
+}

--- a/das_client/logger/lib/src/data/local/log_file_service_impl.dart
+++ b/das_client/logger/lib/src/data/local/log_file_service_impl.dart
@@ -36,6 +36,8 @@ class LogFileServiceImpl implements LogFileService {
   @override
   Future<void> completeCurrentFile() async {
     final currentCacheFile = await _currentCacheFile;
+    if (currentCacheFile.lengthSync() == 0) return;
+
     currentCacheFile.renameSync(await _logFilePathWithTimestamp());
   }
 

--- a/das_client/logger/lib/src/data/logger_repo_impl.dart
+++ b/das_client/logger/lib/src/data/logger_repo_impl.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:clock/clock.dart';
 import 'package:logger/src/data/api/log_api_service.dart';
+import 'package:logger/src/data/api/send_logs_exception.dart';
 import 'package:logger/src/data/local/log_file_service.dart';
 import 'package:logger/src/data/logger_repo.dart';
 import 'package:logger/src/data/mappers.dart';
@@ -54,8 +55,12 @@ class LoggerRepoImpl implements LoggerRepo {
     for (final file in completedLogFiles) {
       try {
         await _sendLogsSync(file);
-      } catch (ex) {
-        _log.severe('Connection error while sending logs to remote.', ex);
+      } on PermanentSendLogsException catch (ex) {
+        _log.severe('Remote rejected logs from ${file.path}, discarding file.', ex);
+        await _tryDelete(file);
+        continue;
+      } on TransientSendLogsException catch (ex) {
+        _log.severe('Temporary error while sending logs to remote, will retry later.', ex);
         _stopSendingUntil = clock.now().add(Duration(minutes: _retryDelayAfterFailedSendMinutes));
         break;
       }

--- a/das_client/logger/test/src/data/api/log_api_service_test.dart
+++ b/das_client/logger/test/src/data/api/log_api_service_test.dart
@@ -5,6 +5,7 @@ import 'package:get_it/get_it.dart';
 import 'package:http_x/component.dart';
 import 'package:logger/component.dart';
 import 'package:logger/src/data/api/log_api_service.dart';
+import 'package:logger/src/data/api/send_logs_exception.dart';
 import 'package:logger/src/data/dto/splunk_log_entry_dto.dart';
 import 'package:logger/src/data/mappers.dart';
 import 'package:logger/src/log_level.dart';
@@ -74,35 +75,90 @@ void main() {
     ).called(1);
   });
 
-  test('sendLogs_whenResponseIsInvalid_shouldThrowHttpException', () async {
+  test('sendLogs_whenResponseIsBadRequest_shouldThrowPermanentWithHttpExceptionCause', () async {
     // ARRANGE
-    final logEntries = _createDummyLogEntries();
-    final mockFile = MockFile();
-    when(mockFile.readAsStringSync()).thenAnswer((_) => logEntries.toJsonString());
+    final mockFile = _mockLogFile();
+    _stubPostWithStatus(mockClient, 400);
 
-    badRequestResponse(Request request) => FakeResponse(
-      statusCode: 400,
-      headers: const {},
-      body: '{"error": "Bad Request"}',
-      request: request,
-    );
+    // ACT & EXPECT
+    try {
+      await testee.sendLogs(mockFile);
+      fail('Expected a PermanentSendLogsException to be thrown.');
+    } catch (e) {
+      expect(e, isA<PermanentSendLogsException>());
+      expect((e as PermanentSendLogsException).cause, isA<BadRequestException>());
+    }
+  });
 
+  for (final statusCode in [400, 404, 413]) {
+    test('sendLogs_whenResponseIs${statusCode}_shouldThrowPermanentSendLogsException', () async {
+      // ARRANGE
+      final mockFile = _mockLogFile();
+      _stubPostWithStatus(mockClient, statusCode);
+
+      // ACT & EXPECT
+      expect(() => testee.sendLogs(mockFile), throwsA(isA<PermanentSendLogsException>()));
+    });
+  }
+
+  for (final statusCode in [401, 403, 408, 429, 500, 503]) {
+    test('sendLogs_whenResponseIs${statusCode}_shouldThrowTransientSendLogsException', () async {
+      // ARRANGE
+      final mockFile = _mockLogFile();
+      _stubPostWithStatus(mockClient, statusCode);
+
+      // ACT & EXPECT
+      expect(() => testee.sendLogs(mockFile), throwsA(isA<TransientSendLogsException>()));
+    });
+  }
+
+  test('sendLogs_whenPostThrows_shouldThrowTransientSendLogsException', () async {
+    // ARRANGE
+    final mockFile = _mockLogFile();
     when(
       mockClient.post(
         any,
         headers: anyNamed('headers'),
         body: anyNamed('body'),
       ),
-    ).thenAnswer((inv) async => badRequestResponse(Request('post', inv.positionalArguments[0])));
+    ).thenThrow(const SocketException('no connection'));
 
     // ACT & EXPECT
-    try {
-      await testee.sendLogs(mockFile);
-      fail('Expected a BadRequestException to be thrown.');
-    } catch (e) {
-      expect(e, isA<BadRequestException>());
-    }
+    expect(() => testee.sendLogs(mockFile), throwsA(isA<TransientSendLogsException>()));
   });
+
+  test('sendLogs_whenEndpointNotConfigured_shouldThrowTransientSendLogsException', () async {
+    // ARRANGE
+    final mockFile = _mockLogFile();
+    GetIt.I.unregister<LogEndpoint>();
+
+    // ACT & EXPECT
+    expect(() => testee.sendLogs(mockFile), throwsA(isA<TransientSendLogsException>()));
+    verifyNever(mockClient.post(any, headers: anyNamed('headers'), body: anyNamed('body')));
+  });
+}
+
+MockFile _mockLogFile() {
+  final mockFile = MockFile();
+  when(mockFile.readAsStringSync()).thenAnswer((_) => _createDummyLogEntries().toJsonString());
+  return mockFile;
+}
+
+void _stubPostWithStatus(MockClient mockClient, int statusCode) {
+  when(
+    mockClient.post(
+      any,
+      headers: anyNamed('headers'),
+      body: anyNamed('body'),
+    ),
+  ).thenAnswer(
+    (inv) async => FakeResponse(
+      statusCode: statusCode,
+      headers: const {},
+      body: '{"text":"No data","code":5}',
+      request: Request('post', inv.positionalArguments[0]),
+    ),
+  );
 }
 
 List<SplunkLogEntryDto> _createDummyLogEntries() {

--- a/das_client/logger/test/src/data/local/log_file_service_test.dart
+++ b/das_client/logger/test/src/data/local/log_file_service_test.dart
@@ -31,6 +31,13 @@ void main() {
     fields: {},
   );
 
+  final largerThanMaxFileSizeLog = SplunkLogEntryDto(
+    time: 0,
+    event: 'A' * (41 * 1024),
+    level: LogLevel.info.name,
+    fields: {},
+  );
+
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('logger_cache_test');
     logDir = Directory(p.join(tempDir.path, fakeApplicationSupportPath, 'splunk-logs'));
@@ -174,6 +181,56 @@ void main() {
 
     // expect
     expect(logDir.listSync().length, equals(1));
+  });
+
+  test('completeCurrentFile_whenNoLogsWritten_shouldNotCreateCompletedFile', () async {
+    // act
+    await testee.completeCurrentFile();
+
+    // expect
+    expect(await testee.hasCompletedLogFiles, false);
+    expect((await testee.completedLogFiles).isEmpty, true);
+  });
+
+  test('completeCurrentFile_whenCalledTwice_shouldOnlyCompleteOnce', () async {
+    // arrange
+    await testee.writeLog(simpleLogFile);
+
+    // act
+    await testee.completeCurrentFile();
+    await testee.completeCurrentFile();
+
+    // expect
+    expect((await testee.completedLogFiles).length, 1);
+    expect((await testee.completedLogFiles).first.readAsStringSync(), simpleLogFile.toJsonString());
+  });
+
+  test('writeLog_whenFirstLogExceedsMaxFileSize_shouldNotCompleteEmptyFile', () async {
+    // act
+    await testee.writeLog(largerThanMaxFileSizeLog);
+
+    // expect
+    expect(await testee.hasCompletedLogFiles, false);
+    expect(logDir.listSync().length, equals(1));
+
+    final content = _currentCacheFile(logDir).readAsStringSync();
+    expect(content, equals(largerThanMaxFileSizeLog.toJsonString()));
+  });
+
+  test('writeLog_whenLogWrittenAfterOversizedLog_shouldCompleteFileContainingOversizedLog', () async {
+    // arrange
+    await testee.writeLog(largerThanMaxFileSizeLog);
+
+    // act
+    await testee.writeLog(simpleLogFile);
+
+    // expect
+    final completedFiles = await testee.completedLogFiles;
+    expect(completedFiles.length, 1);
+    expect(completedFiles.first.readAsStringSync(), largerThanMaxFileSizeLog.toJsonString());
+
+    final content = _currentCacheFile(logDir).readAsStringSync();
+    expect(content, equals(simpleLogFile.toJsonString()));
   });
 
   test('completeCurrentFile_whenHasWrite_shouldRenameFile', () async {

--- a/das_client/logger/test/src/data/logger_repo_test.dart
+++ b/das_client/logger/test/src/data/logger_repo_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/component.dart';
 import 'package:logger/src/data/api/endpoint/send_logs.dart';
 import 'package:logger/src/data/api/log_api_service.dart';
+import 'package:logger/src/data/api/send_logs_exception.dart';
 import 'package:logger/src/data/dto/log_file_dto.dart';
 import 'package:logger/src/data/local/log_file_service.dart';
 import 'package:logger/src/data/logger_repo.dart';
@@ -99,14 +100,14 @@ void main() {
     verify(fileService.deleteLogFile(logFile.file)).called(3);
   });
 
-  test('saveLog_whenSendFails_shouldNotDeleteLogFile', () async {
+  test('saveLog_whenSendFailsTemporarily_shouldNotDeleteLogFile', () async {
     // arrange
     final logFile = LogFileDto(logEntries: [simpleLogFile.toDto()], file: File('fakeFile.json'));
     when(fileService.writeLog(any)).thenAnswer((_) async {});
     when(fileService.hasCompletedLogFiles).thenAnswer((_) async => true);
     when(fileService.completedLogFiles).thenAnswer((_) async => [logFile.file]);
     when(fileService.deleteLogFile(logFile.file)).thenAnswer((_) async {});
-    when(mockSendLogsRequest.call(any)).thenThrow(HttpException('fakeException'));
+    when(mockSendLogsRequest.call(any)).thenThrow(const TransientSendLogsException('fakeException'));
     when(apiService.sendLogs).thenReturn(mockSendLogsRequest);
 
     // act
@@ -139,14 +140,71 @@ void main() {
     verify(fileService.deleteLogFile(logFile.file)).called(1);
   });
 
-  test('saveLog_whenSendFails_shouldNotResendUntilAfterDelay', () async {
+  test('saveLog_whenSendFailsPermanently_shouldDeleteLogFile', () async {
     // arrange
     final logFile = LogFileDto(logEntries: [simpleLogFile.toDto()], file: File('fakeFile.json'));
     when(fileService.writeLog(any)).thenAnswer((_) async {});
     when(fileService.hasCompletedLogFiles).thenAnswer((_) async => true);
     when(fileService.completedLogFiles).thenAnswer((_) async => [logFile.file]);
     when(fileService.deleteLogFile(logFile.file)).thenAnswer((_) async {});
-    when(mockSendLogsRequest.call(any)).thenThrow(HttpException('fakeException'));
+    when(mockSendLogsRequest.call(any)).thenThrow(const PermanentSendLogsException('rejected by remote'));
+    when(apiService.sendLogs).thenReturn(mockSendLogsRequest);
+
+    // act
+    await testee.saveLog(simpleLogFile);
+
+    // expect
+    verify(apiService.sendLogs).called(1);
+    verify(fileService.deleteLogFile(logFile.file)).called(1);
+  });
+
+  test('saveLog_whenSendFailsPermanently_shouldContinueWithRemainingFiles', () async {
+    // arrange
+    final poisonFile = File('poisonFile.json');
+    final goodFile = File('goodFile.json');
+    when(fileService.writeLog(any)).thenAnswer((_) async {});
+    when(fileService.hasCompletedLogFiles).thenAnswer((_) async => true);
+    when(fileService.completedLogFiles).thenAnswer((_) async => [poisonFile, goodFile]);
+    when(fileService.deleteLogFile(any)).thenAnswer((_) async {});
+    when(mockSendLogsRequest.call(poisonFile)).thenThrow(const PermanentSendLogsException('rejected by remote'));
+    when(mockSendLogsRequest.call(goodFile)).thenAnswer((_) async => mockSendLogsResponse);
+    when(apiService.sendLogs).thenReturn(mockSendLogsRequest);
+
+    // act
+    await testee.saveLog(simpleLogFile);
+
+    // expect
+    verify(apiService.sendLogs).called(2);
+    verify(fileService.deleteLogFile(poisonFile)).called(1);
+    verify(fileService.deleteLogFile(goodFile)).called(1);
+  });
+
+  test('saveLog_whenSendFailsPermanently_shouldNotDelayNextSend', () async {
+    // arrange
+    final logFile = LogFileDto(logEntries: [simpleLogFile.toDto()], file: File('fakeFile.json'));
+    when(fileService.writeLog(any)).thenAnswer((_) async {});
+    when(fileService.hasCompletedLogFiles).thenAnswer((_) async => true);
+    when(fileService.completedLogFiles).thenAnswer((_) async => [logFile.file]);
+    when(fileService.deleteLogFile(logFile.file)).thenAnswer((_) async {});
+    when(mockSendLogsRequest.call(any)).thenThrow(const PermanentSendLogsException('rejected by remote'));
+    when(apiService.sendLogs).thenReturn(mockSendLogsRequest);
+
+    // act
+    await testee.saveLog(simpleLogFile);
+    await testee.saveLog(simpleLogFile);
+
+    // expect
+    verify(apiService.sendLogs).called(2);
+  });
+
+  test('saveLog_whenSendFailsTemporarily_shouldNotResendUntilAfterDelay', () async {
+    // arrange
+    final logFile = LogFileDto(logEntries: [simpleLogFile.toDto()], file: File('fakeFile.json'));
+    when(fileService.writeLog(any)).thenAnswer((_) async {});
+    when(fileService.hasCompletedLogFiles).thenAnswer((_) async => true);
+    when(fileService.completedLogFiles).thenAnswer((_) async => [logFile.file]);
+    when(fileService.deleteLogFile(logFile.file)).thenAnswer((_) async {});
+    when(mockSendLogsRequest.call(any)).thenThrow(const TransientSendLogsException('fakeException'));
     when(apiService.sendLogs).thenReturn(mockSendLogsRequest);
     final fiveMinutesFromNow = DateTime.now().add(const Duration(minutes: 5));
 


### PR DESCRIPTION
Two fixes:
- Empty log files would cause 400 response from Splunk, which could end up in a poison pill file (not deleted, retried indefinitely) - very unlikely, but apparently happened.
- Files with 4xx responses from Splunk (except 401, 403, TIMEOUT and THROTTLE) will be marked for deletion, the logs are not recoverable

fix: avoid renaming and sending empty log file to splunk (#2578)