### PR TITLE
feat: timed advancement works without sfera delay (#2491)

### DIFF
--- a/das_client/app/integration_test/test/automatic_advancement_test.dart
+++ b/das_client/app/integration_test/test/automatic_advancement_test.dart
@@ -2,11 +2,13 @@ import 'package:app/di/di.dart';
 import 'package:app/pages/journey/journey_screen/header/header.dart';
 import 'package:app/pages/journey/journey_screen/header/widgets/journey_advancement_button.dart';
 import 'package:app/pages/journey/journey_screen/widgets/table/cells/route_chevron.dart';
+import 'package:app/provider/ru_feature_provider.dart';
 import 'package:app/util/time_constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../integration/integration_test_app.dart';
+import '../mocks/mock_ru_feature_provider.dart';
 import '../util/test_utils.dart';
 
 void main() {
@@ -136,23 +138,72 @@ void main() {
   });
 
   group('timed advancement tests', () {
-    testWidgets('timedAdvancement_whenJourneyLoaded_thenAdvancesCorrectly|6VsC8w1YfGUW4CkTbX7Q|tests:1419', (
-      tester,
-    ) async {
-      await IntegrationTestApp.start(tester);
-      await loadJourney(tester, trainNumber: 'T46M');
+    testWidgets(
+      'timedAdvancement_whenJourneyLoaded_thenAdvancesCorrectly|6VsC8w1YfGUW4CkTbX7Q|tests:1419',
+      (
+        tester,
+      ) async {
+        await IntegrationTestApp.start(tester);
+        await loadJourney(tester, trainNumber: 'T46M');
 
-      // Check journey position at journey start
-      expect(findChevronPositionAtRowWithText('Iselle'), findsAny);
+        // Check journey position at journey start
+        expect(findChevronPositionAtRowWithText('Iselle'), findsAny);
 
-      // Preglia is skipped, because Domodossola (bif) time is before Preglia
-      final locations = ['Varzo', 'Domodossola (bif)', 'Domodossola (I)'];
+        // Preglia is skipped, because Domodossola (bif) time is before Preglia
+        final locations = ['Varzo', 'Domodossola (bif)', 'Domodossola (I)'];
 
-      for (final location in locations) {
-        await waitUntilExists(tester, findChevronPositionAtRowWithText(location));
-      }
+        for (final location in locations) {
+          await waitUntilExists(tester, findChevronPositionAtRowWithText(location));
+        }
 
-      await disconnect(tester);
-    });
+        await disconnect(tester);
+      },
+    );
+
+    testWidgets(
+      'timedAdvancement_whenJourneyLoaded_thenAdvancesByOperationalAndPlannedTimes|Kp3WqzT9rLxYhNv2QmDe|tests:939',
+      (tester) async {
+        await IntegrationTestApp.start(tester);
+        await loadJourney(tester, trainNumber: 'T50');
+
+        // Check journey position at journey start, signal B1 prevents a timed advancement onto Bravo
+        expect(findChevronPositionAtRowWithText('Alpha'), findsAny);
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('B1'));
+
+        // Bravo has no VPro speed: advances at the operational arrival time, ignoring the reported 2min delay
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Bravo'));
+
+        // Charlie has a VPro speed: a signal event with a fresh delay report advances onto it
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Charlie'));
+
+        // Echo has no VPro speed and only a planned time: advances although the punctuality is hidden
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('B4'));
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Echo'));
+
+        await disconnect(tester);
+      },
+    );
+
+    testWidgets(
+      'timedAdvancement_whenSignaledPositionBehindAndPunctualityHidden_thenSignalWins|Xw7RtLm2QpKvYc9HbNd3|tests:2491',
+      (tester) async {
+        await IntegrationTestApp.start(tester);
+        final featureProvider = DI.get<RuFeatureProvider>() as MockRuFeatureProvider;
+        featureProvider.disableFeature(.plannedTimeDeviation);
+        await loadJourney(tester, trainNumber: 'T50');
+
+        // journey advances up to Echo by time, the last event then signals B3 which lies before Echo
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Echo'), maxWaitSeconds: 30);
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('B3'), maxWaitSeconds: 10);
+
+        // Delta (VPro speed) has a long past arrival time but must not advance without a PüA.
+        // No event follows, so this holds no matter how late it runs.
+        await tester.pumpAndSettle(const Duration(seconds: 5));
+        expect(findChevronPositionAtRowWithText('B3'), findsAny);
+        expect(findChevronPositionAtRowWithText('Delta'), findsNothing);
+
+        await disconnect(tester);
+      },
+    );
   });
 }

--- a/das_client/app/integration_test/test/automatic_advancement_test.dart
+++ b/das_client/app/integration_test/test/automatic_advancement_test.dart
@@ -140,9 +140,7 @@ void main() {
   group('timed advancement tests', () {
     testWidgets(
       'timedAdvancement_whenJourneyLoaded_thenAdvancesCorrectly|6VsC8w1YfGUW4CkTbX7Q|tests:1419',
-      (
-        tester,
-      ) async {
+      (tester) async {
         await IntegrationTestApp.start(tester);
         await loadJourney(tester, trainNumber: 'T46M');
 
@@ -192,15 +190,19 @@ void main() {
         featureProvider.disableFeature(.plannedTimeDeviation);
         await loadJourney(tester, trainNumber: 'T50');
 
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Bravo'));
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Charlie'));
+
         // journey advances up to Echo by time, the last event then signals B3 which lies before Echo
-        await waitUntilExists(tester, findChevronPositionAtRowWithText('Echo'), maxWaitSeconds: 30);
-        await waitUntilExists(tester, findChevronPositionAtRowWithText('B3'), maxWaitSeconds: 10);
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Echo'));
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('Charlie'), maxWaitSeconds: 15);
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('B3'));
 
         // Delta (VPro speed) has a long past arrival time but must not advance without a PüA.
         // No event follows, so this holds no matter how late it runs.
         await tester.pumpAndSettle(const Duration(seconds: 5));
-        expect(findChevronPositionAtRowWithText('B3'), findsAny);
-        expect(findChevronPositionAtRowWithText('Delta'), findsNothing);
+        await waitUntilExists(tester, findChevronPositionAtRowWithText('B3'));
+        await waitUntilNotExists(tester, findChevronPositionAtRowWithText('Delta'));
 
         await disconnect(tester);
       },

--- a/das_client/app/lib/extension/datetime_extension.dart
+++ b/das_client/app/lib/extension/datetime_extension.dart
@@ -1,12 +1,6 @@
 extension DateTimeExtension on DateTime {
   DateTime get roundDownToTenthOfSecond => copyWith(
-    year: year,
-    month: month,
-    day: day,
-    hour: hour,
-    minute: minute,
-    second: (second ~/ 10) * 10,
-    millisecond: 0,
+    millisecond: (millisecond ~/ 100) * 100,
     microsecond: 0,
   );
 

--- a/das_client/app/lib/pages/journey/journey_screen/view_model/journey_position_view_model.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/view_model/journey_position_view_model.dart
@@ -53,6 +53,19 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
     }
   }
 
+  @override
+  void dispose() {
+    super.dispose();
+    _journeySubscription?.cancel();
+    _rxModel.close();
+    _rxTimedServicePointReached.close();
+    _rxManualPosition.close();
+    _servicePointReachedTimer?.cancel();
+    _servicePointReachedTimer = null;
+    _manuelPositionAdvancementTimer?.cancel();
+    _manuelPositionAdvancementTimer = null;
+  }
+
   void _startManualPositionTimer(ServicePoint manualPosition) {
     final arrivalTime = manualPosition.arrivalDepartureTime?.bestKnownArrivalTime;
     final manualPositionTime = _manualPositionTime;
@@ -88,18 +101,16 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
         ).listen((data) async {
           _servicePointReachedTimer?.cancel();
 
-          _log.info('Position update triggered');
+          _log.fine('Position update triggered');
 
           final journey = data.$1;
           final punctuality = data.$2;
 
-          if (journey == null) {
-            return;
-          }
+          if (journey == null) return;
 
           _resetAdvancementOnNewSignaledPosition(journey.metadata.signaledPosition);
 
-          final (updatedPosition, isManualPosition) = _calculateCurrentPosition(
+          final updatedPosition = _calculateCurrentPosition(
             journey.metadata.signaledPosition,
             journey.journeyPoints,
           );
@@ -118,12 +129,10 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
             nextServicePoint: _calculateNextServicePoint(updatedPosition, journey.journeyPoints),
             previousStop: _calculatePreviousStop(updatedPosition, journey.journeyPoints),
             nextStop: _calculateNextStop(updatedPosition, journey.journeyPoints),
-            isManualPosition: isManualPosition,
+            isManualPosition: _isManualPosition(updatedPosition),
           );
 
-          if (!_rxModel.isClosed) {
-            _rxModel.add(model);
-          }
+          if (!_rxModel.isClosed) _rxModel.add(model);
         });
   }
 
@@ -162,17 +171,13 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
     return position;
   }
 
-  /// Calculates the current position based on the signaled position, manual position, and timed service point.
-  /// Returns a tuple of the current position and a boolean indicating whether the position is manual.
-  (JourneyPoint?, bool) _calculateCurrentPosition(
+  JourneyPoint? _calculateCurrentPosition(
     SignaledPosition? signaledPosition,
     List<JourneyPoint> journeyPoints,
   ) {
-    bool isManualPosition = false;
-
-    if (journeyPoints.isEmpty) return (null, isManualPosition);
+    if (journeyPoints.isEmpty) return null;
     if (signaledPosition == null && _rxManualPosition.value == null && _rxTimedServicePointReached.value == null) {
-      return (journeyPoints.first, isManualPosition);
+      return journeyPoints.first;
     }
 
     JourneyPoint? currentPosition;
@@ -190,10 +195,9 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
     final manualPosition = _rxManualPosition.value;
     if (manualPosition != null && _currentAdvancementMode.isInManualCycle) {
       currentPosition = _rxManualPosition.value;
-      isManualPosition = true;
     }
 
-    return (currentPosition, isManualPosition);
+    return currentPosition;
   }
 
   ServicePoint? _calculatePreviousServicePoint(
@@ -283,51 +287,50 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
       if (punctuality is! Visible) return;
       arrivalTime = bestKnownArrivalTime.add(punctuality.delay.value);
     } else {
-      // without VPro speeds there is no PüA to consider
+      // no VPro => no PüA to consider
       arrivalTime = bestKnownArrivalTime;
     }
 
     final now = clock.now();
-    final untilNextServicePoint = arrivalTime.add(Duration(milliseconds: 100)).difference(now);
-    _setTimedServicePoint(untilNextServicePoint, nextServicePoint);
+    final untilNextServicePoint = arrivalTime.add(Duration(milliseconds: 50)).difference(now);
+    _setTimedServicePoint(durationUntilNextServicePoint: untilNextServicePoint, nextServicePoint: nextServicePoint);
   }
 
   void _handleTimedRoute(JourneyPoint updatedPosition, List<JourneyPoint> journeyPoints) {
     final nextTimedServicePoint = _timedRouteProvider.calculateNextTimedServicePoint(updatedPosition, journeyPoints);
     if (nextTimedServicePoint != null) {
-      final (secondsUntilNextServicePoint, nextServicePoint) = nextTimedServicePoint;
-      _setTimedServicePoint(secondsUntilNextServicePoint, nextServicePoint);
+      final (durationUntilNextServicePoint, nextServicePoint) = nextTimedServicePoint;
+      _setTimedServicePoint(
+        durationUntilNextServicePoint: durationUntilNextServicePoint,
+        nextServicePoint: nextServicePoint,
+      );
     }
   }
 
-  void _setTimedServicePoint(Duration nextServicePointDuration, ServicePoint nextServicePoint) {
+  void _setTimedServicePoint({
+    required Duration durationUntilNextServicePoint,
+    required ServicePoint nextServicePoint,
+  }) {
     final now = clock.now();
-    if (nextServicePointDuration.inMilliseconds <= 0) {
+    if (durationUntilNextServicePoint.inMilliseconds <= 0) {
       _log.info('Setting timed service point immediately to ${nextServicePoint.name}');
       _rxTimedServicePointReached.add(nextServicePoint);
     } else {
-      final arrivalTime = now.add(nextServicePointDuration);
+      final arrivalTime = now.add(durationUntilNextServicePoint);
       _log.info('Scheduling timed service point for ${nextServicePoint.name} at $arrivalTime');
       _servicePointReachedTimer = Timer(
-        nextServicePointDuration,
+        durationUntilNextServicePoint,
         () {
           _log.info('Setting timed service point to ${nextServicePoint.name}');
-          _rxTimedServicePointReached.add(nextServicePoint);
+          if (!_rxTimedServicePointReached.isClosed) _rxTimedServicePointReached.add(nextServicePoint);
         },
       );
     }
   }
 
-  @override
-  void dispose() {
-    super.dispose();
-    _journeySubscription?.cancel();
-    _rxModel.close();
-    _rxTimedServicePointReached.close();
-    _rxManualPosition.close();
-    _servicePointReachedTimer?.cancel();
-    _servicePointReachedTimer = null;
-    _manuelPositionAdvancementTimer?.cancel();
-    _manuelPositionAdvancementTimer = null;
+  bool _isManualPosition(JourneyPoint? updatedPosition) {
+    return _rxManualPosition.valueOrNull != null &&
+        updatedPosition == _rxManualPosition.value &&
+        _currentAdvancementMode.isInManualCycle;
   }
 }

--- a/das_client/app/lib/pages/journey/journey_screen/view_model/journey_position_view_model.dart
+++ b/das_client/app/lib/pages/journey/journey_screen/view_model/journey_position_view_model.dart
@@ -28,7 +28,6 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
   final JourneySettingsViewModel _journeySettingsViewModel;
   final TimedRouteProvider _timedRouteProvider;
 
-  StreamSubscription<DelayModel>? _punctualitySubscription;
   StreamSubscription<(Journey?, DelayModel, ServicePoint?, JourneyPoint?)>? _journeySubscription;
   final _rxModel = BehaviorSubject.seeded(JourneyPositionModel());
 
@@ -38,6 +37,7 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
   final _rxManualPosition = BehaviorSubject<JourneyPoint?>.seeded(null);
   DateTime? _manualPositionTime;
   Timer? _manuelPositionAdvancementTimer;
+  SignaledPosition? _lastSignaledPosition;
 
   Stream<JourneyPositionModel> get model => _rxModel.distinct();
 
@@ -47,20 +47,19 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
     _log.info('Setting manual position to: $manualPosition');
     _rxManualPosition.add(manualPosition);
     _manualPositionTime = clock.now();
-    if (manualPosition != null && manualPosition is ServicePoint) {
+    _manuelPositionAdvancementTimer?.cancel();
+    if (manualPosition is ServicePoint) {
       _startManualPositionTimer(manualPosition);
     }
   }
 
   void _startManualPositionTimer(ServicePoint manualPosition) {
-    _manuelPositionAdvancementTimer?.cancel();
-
-    final arrivalTime = manualPosition.arrivalDepartureTime?.plannedArrivalTime;
+    final arrivalTime = manualPosition.arrivalDepartureTime?.bestKnownArrivalTime;
     final manualPositionTime = _manualPositionTime;
     final nextServicePoint = lastJourney?.journeyPoints.whereType<ServicePoint>().firstWhereOrNull(
       (it) => it.order > manualPosition.order,
     );
-    final nextArrivalTime = nextServicePoint?.arrivalDepartureTime?.plannedArrivalTime;
+    final nextArrivalTime = nextServicePoint?.arrivalDepartureTime?.bestKnownArrivalTime;
     if (arrivalTime != null && manualPositionTime != null && nextArrivalTime != null) {
       final timeSinceArrival = manualPositionTime.difference(arrivalTime);
       final nextServicePointDuration = nextArrivalTime.add(timeSinceArrival).difference(clock.now());
@@ -98,12 +97,14 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
             return;
           }
 
+          _resetAdvancementOnNewSignaledPosition(journey.metadata.signaledPosition);
+
           final (updatedPosition, isManualPosition) = _calculateCurrentPosition(
             journey.metadata.signaledPosition,
             journey.journeyPoints,
           );
 
-          _calculateAndSetTimedServicePoint(updatedPosition, journey.journeyPoints, punctuality);
+          _calculateAndSetTimedServicePoint(updatedPosition, journey, punctuality);
 
           final calculatedLastPosition = _calculateLastPosition(journey, updatedPosition);
           final lastPosition = calculatedLastPosition == updatedPosition
@@ -124,6 +125,19 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
             _rxModel.add(model);
           }
         });
+  }
+
+  /// A signal advancement has priority over any timed or manual advancement, even if those
+  /// have already advanced further along the route.
+  void _resetAdvancementOnNewSignaledPosition(SignaledPosition? signaledPosition) {
+    final isNewSignaledPosition = signaledPosition != null && signaledPosition != _lastSignaledPosition;
+    _lastSignaledPosition = signaledPosition;
+    if (!isNewSignaledPosition) return;
+
+    _manuelPositionAdvancementTimer?.cancel();
+    _manualPositionTime = null;
+    if (_rxManualPosition.value != null) _rxManualPosition.add(null);
+    if (_rxTimedServicePointReached.value != null) _rxTimedServicePointReached.add(null);
   }
 
   JourneyPoint? _calculateLastPosition(Journey? journey, JourneyPoint? updatedPosition) {
@@ -222,24 +236,26 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
 
   void _calculateAndSetTimedServicePoint(
     JourneyPoint? updatedPosition,
-    List<JourneyPoint> journeyPoints,
+    Journey journey,
     DelayModel punctuality,
   ) {
-    if (_timedRouteProvider.isInTimedAdvancementRoute(updatedPosition, journeyPoints)) {
+    if (_timedRouteProvider.isInTimedAdvancementRoute(updatedPosition, journey.journeyPoints)) {
       _log.info('Journey is in timed advancement route');
-      _handleTimedRoute(updatedPosition!, journeyPoints);
+      _handleTimedRoute(updatedPosition!, journey.journeyPoints);
     } else {
-      _handleSignaledRoute(updatedPosition, journeyPoints, punctuality);
+      _handleSignaledRoute(updatedPosition, journey, punctuality);
     }
   }
 
   void _handleSignaledRoute(
     JourneyPoint? updatedPosition,
-    List<JourneyPoint> journeyPoints,
+    Journey journey,
     DelayModel punctuality,
   ) {
-    if (punctuality is Stale || punctuality is Hidden) return;
     if (updatedPosition is ServicePoint) return;
+
+    final journeyPoints = journey.journeyPoints;
+    if (journeyPoints.isEmpty) return;
 
     final nextPointIndex = journeyPoints.indexOf(updatedPosition ?? journeyPoints.first) + 1;
 
@@ -258,14 +274,21 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
 
     final nextServicePoint = nextPoint;
 
-    final operationalArrivalTime =
-        nextServicePoint.arrivalDepartureTime?.operationalArrivalTime?.roundDownToTenthOfSecond;
-    if (operationalArrivalTime == null) return;
+    final bestKnownArrivalTime = nextServicePoint.arrivalDepartureTime?.bestKnownArrivalTime?.roundDownToTenthOfSecond;
+    if (bestKnownArrivalTime == null) return;
 
-    final arrivalTimeWithDelay = operationalArrivalTime.add((punctuality as Visible).delay.value);
+    final DateTime arrivalTime;
+    if (journey.metadata.calculatedSpeeds[nextServicePoint.order] != null) {
+      // with VPro speeds the PüA drives the advancement, wait for the next signal on stale or missing PüA
+      if (punctuality is! Visible) return;
+      arrivalTime = bestKnownArrivalTime.add(punctuality.delay.value);
+    } else {
+      // without VPro speeds there is no PüA to consider
+      arrivalTime = bestKnownArrivalTime;
+    }
 
     final now = clock.now();
-    final untilNextServicePoint = arrivalTimeWithDelay.add(Duration(milliseconds: 100)).difference(now);
+    final untilNextServicePoint = arrivalTime.add(Duration(milliseconds: 100)).difference(now);
     _setTimedServicePoint(untilNextServicePoint, nextServicePoint);
   }
 
@@ -304,7 +327,7 @@ class JourneyPositionViewModel extends JourneyAwareViewModel {
     _rxManualPosition.close();
     _servicePointReachedTimer?.cancel();
     _servicePointReachedTimer = null;
-    _punctualitySubscription?.cancel();
-    _punctualitySubscription = null;
+    _manuelPositionAdvancementTimer?.cancel();
+    _manuelPositionAdvancementTimer = null;
   }
 }

--- a/das_client/app/lib/provider/timed_route_provider_impl.dart
+++ b/das_client/app/lib/provider/timed_route_provider_impl.dart
@@ -37,7 +37,7 @@ class TimedRouteProviderImpl implements TimedRouteProvider {
     final nextServicePoint = servicePoints
         .skip(updatedPositionIndex + 1)
         .firstWhereOrNull(
-          (sP) => timedRoute.contains(sP.locationCode) && sP.arrivalDepartureTime?.plannedArrivalTime != null,
+          (sP) => timedRoute.contains(sP.locationCode) && sP.arrivalDepartureTime?.bestKnownArrivalTime != null,
         );
     return nextServicePoint;
   }
@@ -56,8 +56,8 @@ class TimedRouteProviderImpl implements TimedRouteProvider {
     if (nextServicePoint == null) return null;
 
     final currentTime = clock.now();
-    final plannedArrivalTime = nextServicePoint.arrivalDepartureTime!.plannedArrivalTime;
+    final arrivalTime = nextServicePoint.arrivalDepartureTime?.bestKnownArrivalTime;
 
-    return (plannedArrivalTime!.difference(currentTime), nextServicePoint);
+    return (arrivalTime!.difference(currentTime), nextServicePoint);
   }
 }

--- a/das_client/app/test/pages/journey/journey_screen/view_model/journey_position_view_model_test.dart
+++ b/das_client/app/test/pages/journey/journey_screen/view_model/journey_position_view_model_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:app/pages/journey/journey_screen/view_model/journey_position_view_model.dart';
 import 'package:app/pages/journey/journey_screen/view_model/model/delay_model.dart';
@@ -54,11 +55,11 @@ void main() {
           );
           emitRegister = <dynamic>[];
           currentPositionSub = testee.model.listen(emitRegister.add);
-          _processStreamInFakeAsync(fakeAsync);
+          fakeAsync.flushMicrotasks();
         });
       });
 
-      _processStreamInFakeAsync(testAsync);
+      testAsync.flushMicrotasks();
       emitRegister.clear();
     });
 
@@ -83,7 +84,7 @@ void main() {
         testAsync.run((_) {
           rxMockJourney.add(Journey(metadata: Metadata(), data: []));
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // ACT & EXPECT
         expect(testee.modelValue, equals(JourneyPositionModel()));
@@ -100,7 +101,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // ACT & EXPECT
         expect(testee.modelValue, equals(JourneyPositionModel()));
@@ -117,7 +118,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // ACT & EXPECT
         expect(testee.modelValue, equals(JourneyPositionModel()));
@@ -125,186 +126,120 @@ void main() {
       });
     });
 
-    test('currentPosition_whenNoSignaledPositionAndNoManualPosition_thenIsFirst', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(Journey(metadata: Metadata(), data: [zeroSignal]));
-      });
-      _processStreamInFakeAsync(testAsync);
+    group('currentPosition calculation', () {
+      test('currentPosition_whenNoSignaledPositionAndNoManualPosition_thenIsFirst', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(Journey(metadata: Metadata(), data: [zeroSignal]));
+        });
+        testAsync.flushMicrotasks();
 
-      // ACT & EXPECT
-      final expectedModel = JourneyPositionModel(currentPosition: zeroSignal);
-      expect(testee.modelValue, equals(expectedModel));
-      expect(emitRegister, hasLength(1));
-      expect(emitRegister.first, equals(expectedModel));
-    });
-
-    test('currentPosition_whenNoSignaledPositionButManualPosition_thenIsManualPosition', () {
-      testAsync.run((_) {
-        rxMockJourney.add(Journey(metadata: Metadata(), data: [zeroSignal]));
-        _processStreamInFakeAsync(testAsync);
-      });
-      emitRegister.clear();
-
-      // ACT
-      testAsync.run((_) {
-        journeySettingsViewModel.updateJourneyAdvancement(Manual());
-        testee.setManualPosition(zeroSignal);
-        _processStreamInFakeAsync(testAsync);
+        // ACT & EXPECT
+        final expectedModel = JourneyPositionModel(currentPosition: zeroSignal);
+        expect(testee.modelValue, equals(expectedModel));
+        expect(emitRegister, hasLength(1));
+        expect(emitRegister.first, equals(expectedModel));
       });
 
-      // EXPECT
-      final expectedModel = JourneyPositionModel(
-        currentPosition: zeroSignal,
-        lastPosition: null,
-        isManualPosition: true,
-      );
-      expect(testee.modelValue, equals(expectedModel));
-      expect(testee.modelValue.isManualPosition, isTrue);
-      expect(emitRegister, hasLength(1));
-      expect(emitRegister.first, equals(expectedModel));
-    });
+      test('currentPosition_whenSignaledPositionOnSignal_thenReturnsSignal', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [tenSignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-    test('currentPosition_whenSignaledPositionOnPoint_thenReturnsPoint', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-            data: [tenSignal],
-          ),
+        // ACT & EXPECT
+        expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal)));
+        expect(emitRegister, hasLength(1));
+      });
+
+      test('currentPosition_whenJourneyUpdatedWithDifferentPointSameOrder_thenReturnsDifferentPoint', () {
+        // ARRANGE
+        final aJourney = Journey(
+          metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+          data: [tenSignal],
+        );
+        final a1Journey = Journey(
+          metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+          data: [tenKilometreSignal],
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(aJourney);
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(a1Journey);
+          testAsync.flushMicrotasks();
+        });
+
+        // ACT & EXPECT
+        expect(
+          emitRegister,
+          orderedEquals([
+            JourneyPositionModel(currentPosition: tenSignal, lastPosition: null),
+            JourneyPositionModel(currentPosition: tenKilometreSignal, lastPosition: null),
+          ]),
         );
       });
-      _processStreamInFakeAsync(testAsync);
 
-      // ACT & EXPECT
-      expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal)));
-      expect(emitRegister, hasLength(1));
-    });
+      test('currentPosition_whenSignaledPositionAfterPoint_thenReturnsPointBefore', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
+              data: [zeroSignal, tenSignal, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-    test('currentPosition_whenJourneyUpdatedWithDifferentPointSameOrder_thenReturnsDifferentPoint', () {
-      // ARRANGE
-      final aJourney = Journey(
-        metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-        data: [tenSignal],
-      );
-      final a1Journey = Journey(
-        metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-        data: [tenKilometreSignal],
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(aJourney);
-        _processStreamInFakeAsync(testAsync);
-        rxMockJourney.add(a1Journey);
-        _processStreamInFakeAsync(testAsync);
+        // ACT & EXPECT
+        expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal)));
+        expect(emitRegister, hasLength(1));
       });
 
-      // ACT & EXPECT
-      expect(
-        emitRegister,
-        orderedEquals([
-          JourneyPositionModel(currentPosition: tenSignal, lastPosition: null),
-          JourneyPositionModel(currentPosition: tenKilometreSignal, lastPosition: null),
-        ]),
-      );
-    });
+      test('currentPosition_whenSignalAndServicePointOnSameOrder_thenPrefersSignal', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, aServicePoint, tenSignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-    test('currentPosition_whenSignaledPositionAfterPoint_thenReturnsPointBefore', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
-            data: [zeroSignal, tenSignal, twentySignal],
-          ),
-        );
+        // ACT & EXPECT
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(emitRegister, hasLength(1));
       });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal)));
-      expect(emitRegister, hasLength(1));
-    });
-
-    test('currentPosition_afterSetManualPositionThenJourneyUpdate_movesToJourneyUpdatePosition', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-        _processStreamInFakeAsync(testAsync);
-        journeySettingsViewModel.updateJourneyAdvancement(Manual());
-        testee.setManualPosition(aServicePoint);
-      });
-      _processStreamInFakeAsync(testAsync);
-      expect(testee.modelValue.currentPosition, equals(aServicePoint));
-      expect(testee.modelValue.isManualPosition, isTrue);
-
-      // ACT
-      testAsync.run((_) {
-        journeySettingsViewModel.updateJourneyAdvancement(Automatic());
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // EXPECT
-      expect(testee.modelValue.currentPosition, equals(bServicePoint));
-      expect(testee.modelValue.isManualPosition, isFalse);
     });
 
     /// TMS VAD cannot send updates for arriving at an actual service point, but only sends an event for the previous
     /// signal (usually an entry signal).
     ///
-    /// To be able to update the location to the service point nevertheless, we use the operational arrival time, the
+    /// To be able to update the location to the service point nevertheless, we use the best known arrival time, the
     /// current time and the reported delay to move the current position to the service point once the train has
     /// theoretically reached the service point.
+    ///
+    /// Which time sources exist depends on the train category:
+    /// * Cargo, empty material and short-term (<2h before departure) journeys: planned and operational times
+    ///   (forecast recalculated at every signal), but never VPro speeds or PüA reports.
+    /// * Passenger trains: planned and operational times, VPro speeds and PüA reports at every signal.
+    /// * Diverted passenger trains: like cargo on the diverted section, like passenger trains on the rest.
+    /// * Only planned times (no operational times) exist for journeys starting abroad and for cargo/empty material
+    ///   journeys started >4h early, in both cases until the first CH signal is passed.
+    ///
+    /// With a VPro speed a fresh PüA is required: on stale or missing PüA the advancement waits for the next
+    /// signal instead.
     group('timed service point advancements', () {
-      test('currentPosition_whenHasNoPunctuality_thenReturnsPointBeforeSP', () {
-        // ARRANGE
-        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 16, kilometre: []);
-        testAsync.run((_) {
-          rxMockJourney.add(
-            Journey(
-              metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
-              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
-            ),
-          );
-        });
-        _processStreamInFakeAsync(testAsync);
-
-        // ACT & EXPECT
-        expect(
-          testee.modelValue,
-          equals(JourneyPositionModel(currentPosition: tenSignal, nextServicePoint: aServicePoint)),
-        );
-        expect(emitRegister, hasLength(1));
-      });
-
-      test('currentPosition_whenSPWithoutOperationalArrivalTime_thenReturnsPointBeforeSP', () {
+      test('currentPosition_whenSPWithoutArrivalTime_thenReturnsPointBeforeSPAndDoesNotTimeAdvance', () {
         // ARRANGE
         final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 16, kilometre: []);
         testAsync.run((_) {
@@ -313,7 +248,7 @@ void main() {
               delay: Delay(value: Duration.zero, location: ''),
             ),
           );
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
           rxMockJourney.add(
             Journey(
               metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
@@ -321,7 +256,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // ACT & EXPECT
         expect(
@@ -331,7 +266,8 @@ void main() {
         expect(emitRegister, hasLength(1));
       });
 
-      test('currentPosition_whenSPWithArrivalTimeAndNoDelay_thenSetsToSPAfterTimer', () {
+      test('currentPosition_whenSPWithOperationalArrivalTimeAndNoDelay_thenSetsToSPAfterOperationalTimeReached', () {
+        // ARRANGE - passenger train: VPro speed and PüA reports are available
         final aServicePoint = ServicePoint(
           name: 'a',
           abbreviation: '',
@@ -350,19 +286,22 @@ void main() {
               delay: Delay(value: Duration.zero, location: ''),
             ),
           );
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
           rxMockJourney.add(
             Journey(
-              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 10),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
               data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         testAsync.elapse(Duration(seconds: 51));
 
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         expect(
           emitRegister,
@@ -378,59 +317,72 @@ void main() {
         expect(emitRegister, hasLength(2));
       });
 
-      test('currentPosition_whenSPWithArrivalTimeAndPositiveDelay_thenReturnsSPAfterTimerWithDelay', () {
-        final now = DateTime(1970);
-        final clock = Clock(() => now);
+      test(
+        'currentPosition_whenSPWithOperationalArrivalTimeAndPositiveDelay_thenReturnsSPAfterOperationalTimeMinusDelay',
+        () {
+          // ARRANGE - passenger train: VPro speed and PüA reports are available
+          final now = DateTime(1970);
+          final clock = Clock(() => now);
 
-        final aServicePoint = ServicePoint(
-          name: 'a',
-          abbreviation: '',
-          locationCode: '',
-          order: 16,
-          kilometre: [],
-          arrivalDepartureTime: ArrivalDepartureTime(
-            plannedArrivalTime: now.add(Duration(seconds: 30)),
-            ambiguousArrivalTime: now.add(Duration(seconds: 50)),
-          ),
-        );
+          final aServicePoint = ServicePoint(
+            name: 'a',
+            abbreviation: '',
+            locationCode: '',
+            order: 16,
+            kilometre: [],
+            arrivalDepartureTime: ArrivalDepartureTime(
+              plannedArrivalTime: now.add(Duration(seconds: 30)),
+              ambiguousArrivalTime: now.add(Duration(seconds: 50)),
+            ),
+          );
 
-        testAsync.run((_) {
-          withClock(clock, () {
-            rxMockPunctuality.add(
-              DelayModel.visible(
-                delay: Delay(value: Duration(minutes: 1), location: ''),
-              ),
-            );
-            _processStreamInFakeAsync(testAsync);
-            rxMockJourney.add(
-              Journey(
-                metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-                data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
-              ),
-            );
+          testAsync.run((_) {
+            withClock(clock, () {
+              rxMockPunctuality.add(
+                DelayModel.visible(
+                  delay: Delay(value: Duration(minutes: 1), location: ''),
+                ),
+              );
+              testAsync.flushMicrotasks();
+              rxMockJourney.add(
+                Journey(
+                  metadata: Metadata(
+                    signaledPosition: SignaledPosition(order: 10),
+                    calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+                  ),
+                  data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+                ),
+              );
+            });
           });
-        });
-        _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
 
-        testAsync.elapse(Duration(seconds: 111));
+          // delay is added to the operational arrival time, so nothing happens before 110s
+          testAsync.elapse(Duration(seconds: 60));
+          testAsync.flushMicrotasks();
+          expect(testee.modelValue.currentPosition, equals(tenSignal));
 
-        _processStreamInFakeAsync(testAsync);
+          testAsync.elapse(Duration(seconds: 51));
 
-        expect(
-          emitRegister,
-          orderedEquals([
-            JourneyPositionModel(currentPosition: tenSignal, nextServicePoint: aServicePoint),
-            JourneyPositionModel(
-              currentPosition: aServicePoint,
-              previousServicePoint: aServicePoint,
-              lastPosition: tenSignal,
-            ),
-          ]),
-        );
-        expect(emitRegister, hasLength(2));
-      });
+          testAsync.flushMicrotasks();
 
-      test('currentPosition_whenSPWithArrivalTimeAndNegativeDelay_thenCurrentPositionIsDirectlySP', () {
+          expect(
+            emitRegister,
+            orderedEquals([
+              JourneyPositionModel(currentPosition: tenSignal, nextServicePoint: aServicePoint),
+              JourneyPositionModel(
+                currentPosition: aServicePoint,
+                previousServicePoint: aServicePoint,
+                lastPosition: tenSignal,
+              ),
+            ]),
+          );
+          expect(emitRegister, hasLength(2));
+        },
+      );
+
+      test('currentPosition_whenSPWithOperationalArrivalTimeAndNegativeDelay_thenCurrentPositionIsDirectlySP', () {
+        // ARRANGE - passenger train: VPro speed and PüA reports are available
         final now = DateTime(1970);
         final clock = Clock(() => now);
 
@@ -454,13 +406,16 @@ void main() {
             );
             rxMockJourney.add(
               Journey(
-                metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+                metadata: Metadata(
+                  signaledPosition: SignaledPosition(order: 10),
+                  calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+                ),
                 data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
               ),
             );
           });
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
         expect(
           emitRegister,
           orderedEquals([
@@ -474,80 +429,490 @@ void main() {
         );
         expect(emitRegister, hasLength(2));
       });
-    });
 
-    test('lastPosition_whenSingleJourney_thenReturnsNull', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-            data: [zeroSignal],
+      test('currentPosition_whenSPWithoutCalculatedSpeed_thenAdvancesByOperationalTimeWithoutDelay', () {
+        // ARRANGE - cargo/empty material/short-term journey: operational forecast times exist, but never VPro or PüA.
+        // A visible delay (e.g. left over from a diverted passenger train) must be ignored for such SPs.
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
           ),
         );
-      });
-      _processStreamInFakeAsync(testAsync);
 
-      // ACT & EXPECT
-      expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: zeroSignal, lastPosition: null)));
-      expect(emitRegister, hasLength(1));
-    });
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration(minutes: 1), location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-    test('lastPosition_whenJourneyUpdatedWithSameCurrentPosition_thenReturnsLastPosition', () {
-      // ARRANGE
-      final aJourney = Journey(
-        metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-        data: [tenSignal],
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(aJourney);
-        _processStreamInFakeAsync(testAsync);
-        rxMockJourney.add(aJourney);
-        _processStreamInFakeAsync(testAsync);
-      });
+        // ACT & EXPECT - the operational arrival time is used, not the planned one
+        testAsync.elapse(Duration(seconds: 35));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
 
-      // ACT & EXPECT
-      expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal, lastPosition: null)));
-      expect(emitRegister, hasLength(1));
-      expect(
-        emitRegister,
-        orderedEquals([
-          JourneyPositionModel(currentPosition: tenSignal, lastPosition: null),
-        ]),
-      );
-    });
-
-    test('lastPosition_whenJourneyUpdatedWithDifferentCurrentPosition_thenReturnsCorrectLastPosition', () {
-      // ARRANGE
-      final aJourney = Journey(
-        metadata: Metadata(),
-        data: [zeroSignal],
-      );
-      final bJourney = Journey(
-        metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
-        data: [zeroSignal, tenSignal],
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(aJourney);
-        _processStreamInFakeAsync(testAsync);
-        rxMockJourney.add(bJourney);
-        _processStreamInFakeAsync(testAsync);
+        // advanced by operational time without the delay applied
+        testAsync.elapse(Duration(seconds: 16));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(emitRegister, hasLength(2));
       });
 
-      // ACT & EXPECT
-      expect(emitRegister, hasLength(2));
-      expect(
-        emitRegister,
-        orderedEquals([
-          JourneyPositionModel(currentPosition: zeroSignal, lastPosition: null),
-          JourneyPositionModel(currentPosition: tenSignal, lastPosition: zeroSignal),
-        ]),
-      );
+      test('currentPosition_whenSPWithoutCalculatedSpeedAndOnlyPlannedArrivalTime_thenAdvancesByPlannedTime', () {
+        // ARRANGE - edge case: journey starting abroad or cargo/empty material started >4h early has only planned
+        // times (no operational times, no VPro, no PüA) until the first CH signal is passed
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+
+        // ACT
+        testAsync.elapse(Duration(seconds: 31));
+        testAsync.flushMicrotasks();
+
+        // EXPECT - advanced by planned time as fallback
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(emitRegister, hasLength(2));
+      });
+
+      test('currentPosition_whenSPWithCalculatedSpeedAndNoPunctuality_thenDoesNotAdvance', () {
+        // ARRANGE - passenger train whose PüA has not (yet) been received: punctuality stays hidden although the SP
+        // has a calculated (VPro) speed, so the advancement waits for the next signal
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 10),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
+              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT
+        testAsync.elapse(Duration(seconds: 120));
+        testAsync.flushMicrotasks();
+
+        // EXPECT - no advancement without visible punctuality
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(emitRegister, hasLength(1));
+      });
+
+      test('currentPosition_whenSPWithCalculatedSpeedAndStalePunctuality_thenDoesNotAdvance', () {
+        // ARRANGE - passenger train whose PüA reports stopped coming in: with a VPro speed the advancement waits for
+        // the next signal instead of using the outdated delay
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.stale(
+              delay: Delay(value: Duration(minutes: 1), location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 10),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
+              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT
+        testAsync.elapse(Duration(seconds: 120));
+        testAsync.flushMicrotasks();
+
+        // EXPECT - no advancement with stale punctuality
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(emitRegister, hasLength(1));
+      });
+
+      test('currentPosition_whenDivertedPassengerTrain_thenAppliesDelayOnlyOnSPsWithCalculatedSpeed', () {
+        // ARRANGE - diverted passenger train: the diverted section behaves like cargo (SP a without VPro/PüA),
+        // the rest like a passenger train (SP b with VPro and PüA)
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
+          ),
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 26,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 90)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 110)),
+          ),
+        );
+        const thirtySignal = Signal(order: 30, kilometre: []);
+        final journeyData = [zeroSignal, tenSignal, aServicePoint, twentySignal, bServicePoint, thirtySignal];
+        final calculatedSpeeds = SplayTreeMap<int, SingleSpeed?>.of({26: const SingleSpeed(value: '80')});
+
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration(minutes: 1), location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 10),
+                calculatedSpeeds: calculatedSpeeds,
+              ),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT - SP a is reached by operational time, the delay is ignored on the diverted section
+        testAsync.elapse(Duration(seconds: 51));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+
+        // the signal after SP a is passed, back on the regular route
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 20),
+                calculatedSpeeds: calculatedSpeeds,
+              ),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(twentySignal));
+
+        // the delay is applied again for SP b, so it is not reached by operational time alone
+        testAsync.elapse(Duration(seconds: 100));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(twentySignal));
+
+        testAsync.elapse(Duration(seconds: 120));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(bServicePoint));
+        expect(emitRegister, hasLength(4));
+      });
+
+      test('currentPosition_whenSignalBetweenPositionAndNextSP_thenDoesNotAdvance', () {
+        // ARRANGE - a signal before the next service point cancels the time-based advancement
+        const fifteenSignal = Signal(order: 15, kilometre: []);
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration.zero, location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, tenSignal, fifteenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT
+        testAsync.elapse(Duration(seconds: 120));
+        testAsync.flushMicrotasks();
+
+        // EXPECT - still on the point before the signal
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(emitRegister, hasLength(1));
+      });
+
+      test('currentPosition_whenOnServicePoint_thenDoesNotAdvanceToNextSPByTime', () {
+        // ARRANGE - time-based advancement only starts from the last signal before a service point
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 50)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration.zero, location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, aServicePoint, bServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT
+        testAsync.elapse(Duration(seconds: 120));
+        testAsync.flushMicrotasks();
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(emitRegister, hasLength(1));
+      });
     });
 
-    test(
-      'lastPosition_whenJourneyUpdatedWithDifferentValuesAndCurrentPosition_thenReturnsCorrectLastPosition',
-      () {
+    group('signaled position priority', () {
+      test('currentPosition_whenNewSignaledPositionBehindTimedAdvancement_thenSignalWins', () {
+        const fifteenSignal = Signal(order: 15, kilometre: []);
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().subtract(Duration(seconds: 30)),
+            ambiguousArrivalTime: now.now().subtract(Duration(seconds: 5)),
+          ),
+        );
+        final journeyData = [zeroSignal, tenSignal, fifteenSignal, aServicePoint, twentySignal];
+
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration.zero, location: ''),
+            ),
+          );
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 15),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+
+        // ACT
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 12),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(testee.modelValue.lastPosition, equals(aServicePoint));
+      });
+
+      test('currentPosition_whenNewSignaledPositionBehindManualPosition_thenSignalWins', () {
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        final journeyData = [zeroSignal, tenSignal, twentySignal, aServicePoint];
+
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 0)),
+              data: journeyData,
+            ),
+          );
+          testAsync.flushMicrotasks();
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+          testAsync.flushMicrotasks();
+        });
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.isManualPosition, isTrue);
+
+        // ACT
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+        expect(testee.modelValue.isManualPosition, isFalse);
+      });
+
+      test('currentPosition_whenJourneyUpdateWithUnchangedSignaledPosition_thenKeepsManualPosition', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        final journeyData = [zeroSignal, tenSignal, twentySignal, aServicePoint];
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: journeyData,
+            ),
+          );
+          testAsync.flushMicrotasks();
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+          testAsync.flushMicrotasks();
+        });
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+
+        // ACT
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: journeyData,
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.isManualPosition, isTrue);
+      });
+    });
+
+    group('lastPosition calculation', () {
+      test('lastPosition_whenJourneyUpdatedWithSameCurrentPosition_thenReturnsLastPosition', () {
+        // ARRANGE
+        final aJourney = Journey(
+          metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+          data: [tenSignal],
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(aJourney);
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(aJourney);
+          testAsync.flushMicrotasks();
+        });
+
+        // ACT & EXPECT
+        expect(testee.modelValue, equals(JourneyPositionModel(currentPosition: tenSignal, lastPosition: null)));
+        expect(emitRegister, hasLength(1));
+        expect(
+          emitRegister,
+          orderedEquals([
+            JourneyPositionModel(currentPosition: tenSignal, lastPosition: null),
+          ]),
+        );
+      });
+
+      test('lastPosition_whenJourneyUpdatedWithDifferentCurrentPosition_thenReturnsCorrectLastPosition', () {
         // ARRANGE
         final aJourney = Journey(
           metadata: Metadata(),
@@ -555,491 +920,578 @@ void main() {
         );
         final bJourney = Journey(
           metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
-          data: [zeroKilometreSignal, tenSignal],
+          data: [zeroSignal, tenSignal],
         );
         testAsync.run((_) {
           rxMockJourney.add(aJourney);
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
           rxMockJourney.add(bJourney);
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
         });
 
         // ACT & EXPECT
+        expect(emitRegister, hasLength(2));
         expect(
           emitRegister,
           orderedEquals([
             JourneyPositionModel(currentPosition: zeroSignal, lastPosition: null),
-            JourneyPositionModel(currentPosition: tenSignal, lastPosition: zeroKilometreSignal),
+            JourneyPositionModel(currentPosition: tenSignal, lastPosition: zeroSignal),
           ]),
         );
-      },
-    );
-
-    test('previousServicePoint_whenNoServicePoints_isNull', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 0)),
-            data: [zeroSignal],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousServicePoint, isNull);
-    });
-
-    test('previousServicePoint_whenNoServicePointBeforeCurrentPosition_isNull', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 0)),
-            data: [zeroSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousServicePoint, isNull);
-    });
-
-    test('previousServicePoint_whenCurrentPositionIsServicePoint_thenIsThisServicePoint', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
-            data: [zeroSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousServicePoint, equals(aServicePoint));
-    });
-
-    test('previousServicePoint_whenCurrentPositionIsAfterServicePoint_thenIsThisServicePoint', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
-      final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 15, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, aServicePoint, bServicePoint, twentySignal],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousServicePoint, equals(bServicePoint));
-    });
-
-    test('nextServicePoint_whenHasNoServicePoints_thenIsNull', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, twentySignal],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextServicePoint, isNull);
-    });
-
-    test('nextServicePoint_whenIsOnServicePointAndNoOther_thenIsNull', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextServicePoint, isNull);
-    });
-
-    test('nextServicePoint_whenIsOnServicePointAndHasOther_thenIsOther', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
-      final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 25, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextServicePoint, equals(bServicePoint));
-    });
-
-    test('previousStop_whenHasNoServicePoints_thenIsNull', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, twentySignal],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousStop, isNull);
-    });
-
-    test('previousStop_whenIsOnServicePointThatIsNoStop_thenIsNull', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousStop, isNull);
-    });
-
-    test('previousStop_whenIsOnServicePointThatIsStopAndNoOther_thenIsThisServicePoint', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousStop, equals(aServicePoint));
-    });
-
-    test('previousStop_whenIsOnServicePointAndFutureOtherThatIsStop_thenIsCurrentOne', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousStop, equals(aServicePoint));
-    });
-
-    test('previousStop_whenIsOnServicePointAndHasPastOtherThatIsStop_thenIsCurrentOne', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.previousStop, equals(bServicePoint));
-    });
-
-    test('nextStop_whenHasNoServicePoints_thenIsNull', () {
-      // ARRANGE
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, twentySignal],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextStop, isNull);
-    });
-
-    test('nextStop_whenIsOnServicePointAndNoOther_thenIsNull', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextStop, isNull);
-    });
-
-    test('nextStop_whenIsOnServicePointAndHasOtherThatIsNoStop_thenIsNull', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 25, kilometre: []);
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-        _processStreamInFakeAsync(testAsync);
       });
 
-      // ACT & EXPECT
-      expect(testee.modelValue.nextStop, isNull);
-    });
-
-    test('nextStop_whenIsOnServicePointAndHasOtherThatIsStop_thenIsOther', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-
-      // ACT & EXPECT
-      expect(testee.modelValue.nextStop, equals(bServicePoint));
-    });
-
-    test('setManualPosition_whenHasNoSignaledPosition_thenMovesCurrentAndLastPosition', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
+      test(
+        'lastPosition_whenJourneyUpdatedWithDifferentValuesAndCurrentPosition_thenReturnsCorrectLastPosition',
+        () {
+          // ARRANGE
+          final aJourney = Journey(
             metadata: Metadata(),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-      expect(testee.modelValue.currentPosition, equals(zeroSignal));
-      expect(testee.modelValue.isManualPosition, isFalse);
+            data: [zeroSignal],
+          );
+          final bJourney = Journey(
+            metadata: Metadata(signaledPosition: SignaledPosition(order: 15)),
+            data: [zeroKilometreSignal, tenSignal],
+          );
+          testAsync.run((_) {
+            rxMockJourney.add(aJourney);
+            testAsync.flushMicrotasks();
+            rxMockJourney.add(bJourney);
+            testAsync.flushMicrotasks();
+          });
 
-      // ACT
-      testAsync.run((async) {
-        journeySettingsViewModel.updateJourneyAdvancement(Manual());
-        testee.setManualPosition(aServicePoint);
-        _processStreamInFakeAsync(async);
-      });
-
-      // EXPECT
-      expect(testee.modelValue.currentPosition, equals(aServicePoint));
-      expect(testee.modelValue.lastPosition, equals(zeroSignal));
-      expect(testee.modelValue.isManualPosition, isTrue);
+          // ACT & EXPECT
+          expect(
+            emitRegister,
+            orderedEquals([
+              JourneyPositionModel(currentPosition: zeroSignal, lastPosition: null),
+              JourneyPositionModel(currentPosition: tenSignal, lastPosition: zeroKilometreSignal),
+            ]),
+          );
+        },
+      );
     });
 
-    test('setManualPosition_whenHasSignaledPosition_thenMovesToNewPosition', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
-        );
-      });
-      _processStreamInFakeAsync(testAsync);
-      expect(testee.modelValue.currentPosition, equals(bServicePoint));
-      expect(testee.modelValue.isManualPosition, isFalse);
+    group('previous and next service point', () {
+      test('previousServicePoint_whenNoServicePoints_isNull', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 0)),
+              data: [zeroSignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-      // ACT
-      testAsync.run((async) {
-        journeySettingsViewModel.updateJourneyAdvancement(Manual());
-        testee.setManualPosition(aServicePoint);
-        _processStreamInFakeAsync(async);
+        // ACT & EXPECT
+        expect(testee.modelValue.previousServicePoint, isNull);
       });
 
-      // EXPECT
-      expect(testee.modelValue.currentPosition, equals(aServicePoint));
-      expect(testee.modelValue.lastPosition, equals(bServicePoint));
-      expect(testee.modelValue.isManualPosition, isTrue);
+      test('previousServicePoint_whenNoServicePointBeforeCurrentPosition_isNull', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 0)),
+              data: [zeroSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousServicePoint, isNull);
+      });
+
+      test('previousServicePoint_whenCurrentPositionIsServicePoint_thenIsThisServicePoint', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousServicePoint, equals(aServicePoint));
+      });
+
+      test('previousServicePoint_whenCurrentPositionIsAfterServicePoint_thenIsThisServicePoint', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 10, kilometre: []);
+        final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 15, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, aServicePoint, bServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousServicePoint, equals(bServicePoint));
+      });
+
+      test('nextServicePoint_whenHasNoServicePoints_thenIsNull', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextServicePoint, isNull);
+      });
+
+      test('nextServicePoint_whenIsOnServicePointAndNoOther_thenIsNull', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextServicePoint, isNull);
+      });
+
+      test('nextServicePoint_whenIsOnServicePointAndHasOther_thenIsOther', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
+        final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 25, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextServicePoint, equals(bServicePoint));
+      });
     });
 
-    test('setManualPosition_whenIsGivenNullPosition_thenMovesToSignaledPosition', () {
-      // ARRANGE
-      final aServicePoint = ServicePoint(
-        name: 'a',
-        abbreviation: '',
-        locationCode: '',
-        order: 20,
-        kilometre: [],
-        isStop: true,
-      );
-      final bServicePoint = ServicePoint(
-        name: 'b',
-        abbreviation: '',
-        locationCode: '',
-        order: 25,
-        kilometre: [],
-        isStop: true,
-      );
-      testAsync.run((_) {
-        rxMockJourney.add(
-          Journey(
-            metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
-            data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-          ),
+    group('previous and next stop', () {
+      test('previousStop_whenHasNoServicePoints_thenIsNull', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousStop, isNull);
+      });
+
+      test('previousStop_whenIsOnServicePointThatIsNoStop_thenIsNull', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousStop, isNull);
+      });
+
+      test('previousStop_whenIsOnServicePointThatIsStopAndNoOther_thenIsThisServicePoint', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
         );
-      });
-      _processStreamInFakeAsync(testAsync);
-      expect(testee.modelValue.currentPosition, equals(bServicePoint));
-      expect(testee.modelValue.isManualPosition, isFalse);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
 
-      testAsync.run((async) {
-        journeySettingsViewModel.updateJourneyAdvancement(Manual());
-        testee.setManualPosition(aServicePoint);
-        _processStreamInFakeAsync(async);
-      });
-
-      expect(testee.modelValue.currentPosition, equals(aServicePoint));
-      expect(testee.modelValue.lastPosition, equals(bServicePoint));
-      expect(testee.modelValue.isManualPosition, isTrue);
-
-      // ACT
-      testAsync.run((_) {
-        testee.setManualPosition(null);
-        _processStreamInFakeAsync(testAsync);
+        // ACT & EXPECT
+        expect(testee.modelValue.previousStop, equals(aServicePoint));
       });
 
-      expect(testee.modelValue.currentPosition, equals(bServicePoint));
-      expect(testee.modelValue.lastPosition, equals(aServicePoint));
-      expect(testee.modelValue.isManualPosition, isFalse);
+      test('previousStop_whenIsOnServicePointAndFutureOtherThatIsStop_thenIsCurrentOne', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousStop, equals(aServicePoint));
+      });
+
+      test('previousStop_whenIsOnServicePointAndHasPastOtherThatIsStop_thenIsCurrentOne', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.previousStop, equals(bServicePoint));
+      });
+
+      test('nextStop_whenHasNoServicePoints_thenIsNull', () {
+        // ARRANGE
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextStop, isNull);
+      });
+
+      test('nextStop_whenIsOnServicePointAndNoOther_thenIsNull', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(name: 'a', abbreviation: '', locationCode: '', order: 20, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextStop, isNull);
+      });
+
+      test('nextStop_whenIsOnServicePointAndHasOtherThatIsNoStop_thenIsNull', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(name: 'b', abbreviation: '', locationCode: '', order: 25, kilometre: []);
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+          testAsync.flushMicrotasks();
+        });
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextStop, isNull);
+      });
+
+      test('nextStop_whenIsOnServicePointAndHasOtherThatIsStop_thenIsOther', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 20)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // ACT & EXPECT
+        expect(testee.modelValue.nextStop, equals(bServicePoint));
+      });
+    });
+
+    group('manual position', () {
+      test('setManualPosition_whenHasNoSignaledPosition_thenMovesCurrentAndLastPosition', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(zeroSignal));
+        expect(testee.modelValue.isManualPosition, isFalse);
+
+        // ACT
+        testAsync.run((async) {
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+          async.flushMicrotasks();
+        });
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.lastPosition, equals(zeroSignal));
+        expect(testee.modelValue.isManualPosition, isTrue);
+      });
+
+      test('setManualPosition_whenHasSignaledPosition_thenMovesToNewPosition', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(bServicePoint));
+        expect(testee.modelValue.isManualPosition, isFalse);
+
+        // ACT
+        testAsync.run((async) {
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+          async.flushMicrotasks();
+        });
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.lastPosition, equals(bServicePoint));
+        expect(testee.modelValue.isManualPosition, isTrue);
+      });
+
+      test('setManualPosition_whenIsGivenNullPosition_thenMovesToSignaledPosition', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(bServicePoint));
+        expect(testee.modelValue.isManualPosition, isFalse);
+
+        testAsync.run((async) {
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+          async.flushMicrotasks();
+        });
+
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.lastPosition, equals(bServicePoint));
+        expect(testee.modelValue.isManualPosition, isTrue);
+
+        // ACT
+        testAsync.run((_) {
+          testee.setManualPosition(null);
+          testAsync.flushMicrotasks();
+        });
+
+        expect(testee.modelValue.currentPosition, equals(bServicePoint));
+        expect(testee.modelValue.lastPosition, equals(aServicePoint));
+        expect(testee.modelValue.isManualPosition, isFalse);
+      });
+
+      test('currentPosition_afterSetManualPositionThenJourneyUpdate_movesToJourneyUpdatePosition', () {
+        // ARRANGE
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 20,
+          kilometre: [],
+          isStop: true,
+        );
+        final bServicePoint = ServicePoint(
+          name: 'b',
+          abbreviation: '',
+          locationCode: '',
+          order: 25,
+          kilometre: [],
+          isStop: true,
+        );
+        testAsync.run((_) {
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 10)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+          testAsync.flushMicrotasks();
+          journeySettingsViewModel.updateJourneyAdvancement(Manual());
+          testee.setManualPosition(aServicePoint);
+        });
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+        expect(testee.modelValue.isManualPosition, isTrue);
+
+        // ACT
+        testAsync.run((_) {
+          journeySettingsViewModel.updateJourneyAdvancement(Automatic());
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(signaledPosition: SignaledPosition(order: 25)),
+              data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        // EXPECT
+        expect(testee.modelValue.currentPosition, equals(bServicePoint));
+        expect(testee.modelValue.isManualPosition, isFalse);
+      });
     });
 
     group('setManualPosition timer advancement', () {
@@ -1081,10 +1533,10 @@ void main() {
                 data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
               ),
             );
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
             journeySettingsViewModel.updateJourneyAdvancement(Manual());
             testee.setManualPosition(aServicePoint);
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
           expect(testee.modelValue.currentPosition, equals(aServicePoint));
           expect(testee.modelValue.isManualPosition, isTrue);
@@ -1092,7 +1544,7 @@ void main() {
 
           // ACT – elapse past the 40 s timer
           testAsync.elapse(Duration(seconds: 41));
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
 
           // EXPECT
           expect(testee.modelValue.currentPosition, equals(bServicePoint));
@@ -1133,65 +1585,16 @@ void main() {
                 data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
               ),
             );
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
             journeySettingsViewModel.updateJourneyAdvancement(Manual());
             testee.setManualPosition(aServicePoint);
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
           emitRegister.clear();
 
           // ACT
           testAsync.elapse(Duration(seconds: 100));
-          _processStreamInFakeAsync(testAsync);
-
-          // EXPECT – still on A
-          expect(testee.modelValue.currentPosition, equals(aServicePoint));
-          expect(testee.modelValue.isManualPosition, isTrue);
-          expect(emitRegister, hasLength(0));
-        },
-      );
-
-      test(
-        'setManualPosition_whenNextSPHasNoArrivalTime_thenDoesNotAutoAdvance',
-        () {
-          // ARRANGE – A has arrival time but B does not → no timer is set
-          final aServicePoint = ServicePoint(
-            name: 'a',
-            abbreviation: '',
-            locationCode: '',
-            order: 20,
-            kilometre: [],
-            isStop: true,
-            arrivalDepartureTime: ArrivalDepartureTime(
-              plannedArrivalTime: now.now().subtract(Duration(seconds: 10)),
-            ),
-          );
-          final bServicePoint = ServicePoint(
-            name: 'b',
-            abbreviation: '',
-            locationCode: '',
-            order: 25,
-            kilometre: [],
-            isStop: true,
-          );
-
-          testAsync.run((_) {
-            rxMockJourney.add(
-              Journey(
-                metadata: Metadata(),
-                data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
-              ),
-            );
-            _processStreamInFakeAsync(testAsync);
-            journeySettingsViewModel.updateJourneyAdvancement(Manual());
-            testee.setManualPosition(aServicePoint);
-            _processStreamInFakeAsync(testAsync);
-          });
-          emitRegister.clear();
-
-          // ACT
-          testAsync.elapse(Duration(seconds: 100));
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
 
           // EXPECT – still on A
           expect(testee.modelValue.currentPosition, equals(aServicePoint));
@@ -1244,16 +1647,16 @@ void main() {
                 data: [zeroSignal, aServicePoint, bServicePoint, cServicePoint],
               ),
             );
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
             journeySettingsViewModel.updateJourneyAdvancement(Manual());
             testee.setManualPosition(aServicePoint); // starts A→B timer (40 s)
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
 
           // Override with B before the timer fires → cancels A→B timer
           testAsync.run((_) {
             testee.setManualPosition(bServicePoint);
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
           expect(testee.modelValue.currentPosition, equals(bServicePoint));
           expect(testee.modelValue.isManualPosition, isTrue);
@@ -1261,7 +1664,7 @@ void main() {
 
           // ACT – advance past where A→B timer would have fired
           testAsync.elapse(Duration(seconds: 50));
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
 
           // EXPECT – position remains B (old timer did not fire)
           expect(testee.modelValue.currentPosition, equals(bServicePoint));
@@ -1304,10 +1707,10 @@ void main() {
                 data: [zeroSignal, tenSignal, aServicePoint, bServicePoint],
               ),
             );
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
             journeySettingsViewModel.updateJourneyAdvancement(Manual());
             testee.setManualPosition(aServicePoint); // starts A→B timer (40 s)
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
           expect(testee.modelValue.currentPosition, equals(aServicePoint));
           expect(testee.modelValue.isManualPosition, isTrue);
@@ -1315,18 +1718,91 @@ void main() {
           // Switch back to Automatic before timer fires
           testAsync.run((_) {
             journeySettingsViewModel.updateJourneyAdvancement(Automatic());
-            _processStreamInFakeAsync(testAsync);
+            testAsync.flushMicrotasks();
           });
           emitRegister.clear();
 
           // ACT – let the timer fire
           testAsync.elapse(Duration(seconds: 41));
-          _processStreamInFakeAsync(testAsync);
+          testAsync.flushMicrotasks();
 
           // EXPECT – guard `isInManualCycle` prevented the advancement
           expect(testee.modelValue.currentPosition, isNot(equals(bServicePoint)));
           expect(testee.modelValue.isManualPosition, isTrue);
           expect(emitRegister, hasLength(0));
+        },
+      );
+
+      test(
+        'setManualPosition_whenTimerAdvances_thenContinuesAdvancingWithSameTimeDifference',
+        () {
+          // ARRANGE
+          // arrivalTime of A = T - 10s, so timeSinceArrival = 10s
+          // arrivalTime of B = T + 30s => advancement to B after 40s
+          // arrivalTime of C = T + 60s => advancement to C 30s after B (time difference of 10s is kept)
+          final aServicePoint = ServicePoint(
+            name: 'a',
+            abbreviation: '',
+            locationCode: '',
+            order: 20,
+            kilometre: [],
+            isStop: true,
+            arrivalDepartureTime: ArrivalDepartureTime(
+              plannedArrivalTime: now.now().subtract(Duration(seconds: 10)),
+            ),
+          );
+          final bServicePoint = ServicePoint(
+            name: 'b',
+            abbreviation: '',
+            locationCode: '',
+            order: 25,
+            kilometre: [],
+            isStop: true,
+            arrivalDepartureTime: ArrivalDepartureTime(
+              plannedArrivalTime: now.now().add(Duration(seconds: 30)),
+            ),
+          );
+          final cServicePoint = ServicePoint(
+            name: 'c',
+            abbreviation: '',
+            locationCode: '',
+            order: 30,
+            kilometre: [],
+            isStop: true,
+            arrivalDepartureTime: ArrivalDepartureTime(
+              plannedArrivalTime: now.now().add(Duration(seconds: 60)),
+            ),
+          );
+
+          testAsync.run((_) {
+            rxMockJourney.add(
+              Journey(
+                metadata: Metadata(),
+                data: [zeroSignal, aServicePoint, bServicePoint, cServicePoint],
+              ),
+            );
+            testAsync.flushMicrotasks();
+            journeySettingsViewModel.updateJourneyAdvancement(Manual());
+            testee.setManualPosition(aServicePoint);
+            testAsync.flushMicrotasks();
+          });
+          expect(testee.modelValue.currentPosition, equals(aServicePoint));
+
+          // ACT & EXPECT – advances to B after 40s
+          testAsync.elapse(Duration(seconds: 41));
+          testAsync.flushMicrotasks();
+          expect(testee.modelValue.currentPosition, equals(bServicePoint));
+
+          // still on B before C is due
+          testAsync.elapse(Duration(seconds: 20));
+          testAsync.flushMicrotasks();
+          expect(testee.modelValue.currentPosition, equals(bServicePoint));
+
+          // advances to C with the preserved time difference
+          testAsync.elapse(Duration(seconds: 10));
+          testAsync.flushMicrotasks();
+          expect(testee.modelValue.currentPosition, equals(cServicePoint));
+          expect(testee.modelValue.isManualPosition, isTrue);
         },
       );
     });
@@ -1367,7 +1843,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         expect(testee.modelValue.currentPosition, equals(point1));
         expect(testee.modelValue.isManualPosition, isFalse);
@@ -1376,7 +1852,7 @@ void main() {
 
         // ACT - Elapse time until service point should be reached
         testAsync.elapse(Duration(seconds: 41));
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // EXPECT - Position should now be at the next timed service point
         expect(
@@ -1425,7 +1901,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         expect(testee.modelValue.currentPosition, equals(point1));
         expect(testee.modelValue.isManualPosition, isFalse);
@@ -1433,7 +1909,7 @@ void main() {
 
         // ACT - Elapse time until service point should be reached
         testAsync.elapse(Duration(seconds: 36));
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // EXPECT - Position should advance to second timed service point
         expect(
@@ -1471,7 +1947,7 @@ void main() {
             ),
           );
         });
-        _processStreamInFakeAsync(testAsync);
+        testAsync.flushMicrotasks();
 
         // EXPECT - Position is set to service point immediately
         expect(
@@ -1484,5 +1960,3 @@ void main() {
     });
   });
 }
-
-void _processStreamInFakeAsync(FakeAsync testAsync) => testAsync.elapse(const Duration(milliseconds: 5));

--- a/das_client/app/test/pages/journey/journey_screen/view_model/journey_position_view_model_test.dart
+++ b/das_client/app/test/pages/journey/journey_screen/view_model/journey_position_view_model_test.dart
@@ -317,6 +317,48 @@ void main() {
         expect(emitRegister, hasLength(2));
       });
 
+      test('currentPosition_whenArrivalTimeOffTenSecondBoundary_thenDoesNotAdvanceEarly', () {
+        // ARRANGE - guards against flooring the arrival time to whole ten seconds of the wall clock
+        final aServicePoint = ServicePoint(
+          name: 'a',
+          abbreviation: '',
+          locationCode: '',
+          order: 16,
+          kilometre: [],
+          arrivalDepartureTime: ArrivalDepartureTime(
+            plannedArrivalTime: now.now().add(Duration(seconds: 47)),
+            ambiguousArrivalTime: now.now().add(Duration(seconds: 33)),
+          ),
+        );
+
+        testAsync.run((_) {
+          rxMockPunctuality.add(
+            DelayModel.visible(
+              delay: Delay(value: Duration.zero, location: ''),
+            ),
+          );
+          testAsync.flushMicrotasks();
+          rxMockJourney.add(
+            Journey(
+              metadata: Metadata(
+                signaledPosition: SignaledPosition(order: 10),
+                calculatedSpeeds: SplayTreeMap.of({16: const SingleSpeed(value: '80')}),
+              ),
+              data: [zeroSignal, tenSignal, aServicePoint, twentySignal],
+            ),
+          );
+        });
+        testAsync.flushMicrotasks();
+
+        testAsync.elapse(Duration(seconds: 31));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(tenSignal));
+
+        testAsync.elapse(Duration(seconds: 3));
+        testAsync.flushMicrotasks();
+        expect(testee.modelValue.currentPosition, equals(aServicePoint));
+      });
+
       test(
         'currentPosition_whenSPWithOperationalArrivalTimeAndPositiveDelay_thenReturnsSPAfterOperationalTimeMinusDelay',
         () {

--- a/das_client/sfera/lib/src/model/journey/arrival_departure_time.dart
+++ b/das_client/sfera/lib/src/model/journey/arrival_departure_time.dart
@@ -32,10 +32,16 @@ class ArrivalDepartureTime {
 
   DateTime? get operationalDepartureTime => _isDepartureTimeCalculated ? _ambiguousDepartureTime : null;
 
+  /// The most accurate known departure time: operational time when available, planned time otherwise.
+  DateTime? get bestKnownDepartureTime => operationalDepartureTime ?? plannedDepartureTime;
+
   DateTime? get plannedArrivalTime =>
       _isArrivalTimeCalculated ? _plannedArrivalTime : _ambiguousArrivalTime ?? _plannedArrivalTime;
 
   DateTime? get operationalArrivalTime => _isArrivalTimeCalculated ? _ambiguousArrivalTime : null;
+
+  /// The most accurate known arrival time: operational time when available, planned time otherwise.
+  DateTime? get bestKnownArrivalTime => operationalArrivalTime ?? plannedArrivalTime;
 
   bool get _isDepartureTimeCalculated => _ambiguousDepartureTime != null && _plannedDepartureTime != null;
 

--- a/das_client/sfera/test/src/model/journey/arrival_departure_time_test.dart
+++ b/das_client/sfera/test/src/model/journey/arrival_departure_time_test.dart
@@ -102,6 +102,68 @@ void main() {
     expect(time.plannedArrivalTime, DateTime(2025, 5, 13, 16, 0));
   });
 
+  test('bestKnownDepartureTime_whenBothAmbiguousAndPlannedDepartureTimesAreProvided_thenReturnsOperationalTime', () {
+    final time = ArrivalDepartureTime(
+      ambiguousDepartureTime: DateTime(2025, 5, 13, 12, 0),
+      plannedDepartureTime: DateTime(2025, 5, 13, 11, 0),
+    );
+
+    expect(time.bestKnownDepartureTime, DateTime(2025, 5, 13, 12, 0));
+  });
+
+  test('bestKnownDepartureTime_whenOnlyPlannedDepartureTimeIsProvided_thenReturnsPlannedTime', () {
+    final time = ArrivalDepartureTime(
+      plannedDepartureTime: DateTime(2025, 5, 13, 11, 0),
+    );
+
+    expect(time.bestKnownDepartureTime, DateTime(2025, 5, 13, 11, 0));
+  });
+
+  test('bestKnownDepartureTime_whenOnlyAmbiguousDepartureTimeIsProvided_thenReturnsAmbiguousTime', () {
+    final time = ArrivalDepartureTime(
+      ambiguousDepartureTime: DateTime(2025, 5, 13, 12, 0),
+    );
+
+    expect(time.bestKnownDepartureTime, DateTime(2025, 5, 13, 12, 0));
+  });
+
+  test('bestKnownDepartureTime_whenNoDepartureTimeIsProvided_thenReturnsNull', () {
+    final time = ArrivalDepartureTime();
+
+    expect(time.bestKnownDepartureTime, isNull);
+  });
+
+  test('bestKnownArrivalTime_whenBothAmbiguousAndPlannedArrivalTimesAreProvided_thenReturnsOperationalTime', () {
+    final time = ArrivalDepartureTime(
+      ambiguousArrivalTime: DateTime(2025, 5, 13, 15, 0),
+      plannedArrivalTime: DateTime(2025, 5, 13, 16, 0),
+    );
+
+    expect(time.bestKnownArrivalTime, DateTime(2025, 5, 13, 15, 0));
+  });
+
+  test('bestKnownArrivalTime_whenOnlyPlannedArrivalTimeIsProvided_thenReturnsPlannedTime', () {
+    final time = ArrivalDepartureTime(
+      plannedArrivalTime: DateTime(2025, 5, 13, 16, 0),
+    );
+
+    expect(time.bestKnownArrivalTime, DateTime(2025, 5, 13, 16, 0));
+  });
+
+  test('bestKnownArrivalTime_whenOnlyAmbiguousArrivalTimeIsProvided_thenReturnsAmbiguousTime', () {
+    final time = ArrivalDepartureTime(
+      ambiguousArrivalTime: DateTime(2025, 5, 13, 15, 0),
+    );
+
+    expect(time.bestKnownArrivalTime, DateTime(2025, 5, 13, 15, 0));
+  });
+
+  test('bestKnownArrivalTime_whenNoArrivalTimeIsProvided_thenReturnsNull', () {
+    final time = ArrivalDepartureTime();
+
+    expect(time.bestKnownArrivalTime, isNull);
+  });
+
   test('hasAnyTime_whenNoTime_thenReturnsFalse', () {
     final time = ArrivalDepartureTime();
 

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_16000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_16000.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <!-- Signal B2 with a fresh delay report: the operational arrival time of Charlie (VPro speed)
+                     plus this delay is already reached, so the advancement follows immediately -->
+                <PositionSpeed SP_ID="T50_1" location="3000">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0M2S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_22000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_22000.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <!-- Signal B4: Echo has no VPro speed and only a planned time, the timed advancement
+                     onto it happens although the punctuality is hidden by now -->
+                <PositionSpeed SP_ID="T50_1" location="6500">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT0M2S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_30000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_30000.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T50_1" location="4000">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_32000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_32000.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <PositionSpeed SP_ID="T50_1" location="5000">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_8000.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_Event_T50_8000.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<G2B_EventPayload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <RelatedTrainInformation>
+        <OwnTrain>
+            <TrainIdentification>
+                <OTN_ID>
+                    <teltsi_Company>1285</teltsi_Company>
+                    <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+                    <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+                </OTN_ID>
+            </TrainIdentification>
+            <TrainLocationInformation>
+                <!-- Signal B1: Bravo has no VPro speed, the timed advancement onto it at the operational
+                     arrival time must ignore this delay -->
+                <PositionSpeed SP_ID="T50_1" location="1000">
+                    <SP_Zone>
+                        <IM_ID>0085</IM_ID>
+                    </SP_Zone>
+                </PositionSpeed>
+                <Delay Delay="PT2M0S"/>
+            </TrainLocationInformation>
+        </OwnTrain>
+    </RelatedTrainInformation>
+</G2B_EventPayload>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_JP_T50.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_JP_T50.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!-- Timed advancement edge cases. Timeline relative to registration (see SFERA_Event_T50_* offsets),
+     tuned to the TestTimeConstants of the client integration tests (punctuality stale after 2s, hidden after 5s):
+     - Bravo (no VPro speed): advances at the operational arrival time (13s), ignoring the delay reported
+       at 8s and preferring the operational over the planned time (50s).
+     - Charlie (VPro speed): the fresh delay reported with signal B2 at 16s added to the operational arrival
+       time (14s) is already reached, so the advancement follows immediately.
+     - Echo (no VPro speed, planned time only): after signal B4 at 22s, advances at the planned arrival
+       time (26s) regardless of the PüA state.
+     - Signal B3 at 32s lies behind the already advanced position Echo and takes priority. It is the last
+       event and carries no delay, so the punctuality is hidden and the long past operational arrival time
+       of Delta (VPro speed) never triggers a timed advancement - the chevron stays on B3 for good. -->
+<JourneyProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" JP_Status="Valid" JP_Version="1" xsi:noNamespaceSchemaLocation="../../SFERA.xsd">
+    <TrainIdentification>
+        <OTN_ID>
+            <teltsi_Company>1285</teltsi_Company>
+            <teltsi_OperationalTrainNumber>T50</teltsi_OperationalTrainNumber>
+            <teltsi_StartDate>2026-08-11</teltsi_StartDate>
+        </OTN_ID>
+    </TrainIdentification>
+    <SegmentProfileReference SP_ID="T50_1" SP_VersionMajor="1" SP_VersionMinor="0" SP_Direction="Nominal">
+        <SP_Zone>
+            <IM_ID>0085</IM_ID>
+        </SP_Zone>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Alpha"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:00:13Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:00:50Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Bravo"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:00:14Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:00:55Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Charlie"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:00:20Z"
+                                TP_PlannedLatestArrivalTime="9999-01-01T00:01:00Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Delta"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <!-- Echo has no operational arrival time -->
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None" TP_latestArrivalTime="9999-01-01T00:00:26Z">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Echo"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+        <TimingPointConstraints TP_StopSkipPass="Stopping_Point" TP_Information="None">
+            <TimingPointReference>
+                <TP_ID_Reference TP_ID="Foxtrot"/>
+            </TimingPointReference>
+        </TimingPointConstraints>
+
+        <TrainCharacteristicsRef TC_ID="T50_1" TC_VersionMajor="1" TC_VersionMinor="0" location="0">
+            <TC_RU_ID>1185</TC_RU_ID>
+        </TrainCharacteristicsRef>
+
+        <!-- VPro speeds (and with them PüA punctuality reports) only exist on Charlie and Delta -->
+        <JP_ContextInformation>
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="90"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="4000" endLocation="4000"/>
+            </JP_ContextInformation_NSPs>
+            <JP_ContextInformation_NSPs>
+                <teltsi_Company>0085</teltsi_Company>
+                <NSP_GroupName>VProSpeed</NSP_GroupName>
+                <NetworkSpecificParameter name="newSpeed" value="80"/>
+                <JP_ContextInformation_NSP_Constraints startEndQualifier="StartsEnds" startLocation="6000" endLocation="6000"/>
+            </JP_ContextInformation_NSPs>
+        </JP_ContextInformation>
+    </SegmentProfileReference>
+</JourneyProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_SP_T50_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_SP_T50_1.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0"?>
+<SegmentProfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd" SP_ID="T50_1" SP_VersionMajor="1"
+                SP_VersionMinor="0" SP_Length="10000" SP_Status="Valid">
+    <SP_Zone>
+        <IM_ID>0085</IM_ID>
+    </SP_Zone>
+    <SP_Points>
+
+        <TimingPoint TP_ID="Alpha" location="500">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5001</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <TimingPoint TP_ID="Bravo" location="2000">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5002</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <TimingPoint TP_ID="Charlie" location="4000">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5003</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <TimingPoint TP_ID="Delta" location="6000">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5004</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <TimingPoint TP_ID="Echo" location="7500">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5005</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <TimingPoint TP_ID="Foxtrot" location="9000">
+            <TAF_TAP_LocationReference>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5006</teltsi_LocationPrimaryCode>
+            </TAF_TAP_LocationReference>
+        </TimingPoint>
+
+        <!-- Exactly one block signal between consecutive service points, so each timed advancement onto the
+             following service point is only possible once the train was signaled on the block signal before it. -->
+        <Signal>
+            <Signal_ID signal_ID_Physical="1" location="1000"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B1"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="2" location="3000"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B2"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="3" location="5000"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B3"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="4" location="6500"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B4"/>
+        </Signal>
+        <Signal>
+            <Signal_ID signal_ID_Physical="5" location="8000"/>
+            <SignalFunction>block</SignalFunction>
+            <SignalPhysicalCharacteristics visualIdentifier="B5"/>
+        </Signal>
+
+    </SP_Points>
+    <SP_Areas>
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="500" endLocation="500" TAF_TAP_location_abbreviation="ALP"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5001</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Alpha</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="2000" endLocation="2000" TAF_TAP_location_abbreviation="BRA"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5002</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Bravo</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="4000" endLocation="4000" TAF_TAP_location_abbreviation="CHA"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5003</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Charlie</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="6000" endLocation="6000" TAF_TAP_location_abbreviation="DEL"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5004</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Delta</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="7500" endLocation="7500" TAF_TAP_location_abbreviation="ECH"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5005</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Echo</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+
+        <TAF_TAP_Location startEndQualifier="StartsEnds" startLocation="9000" endLocation="9000" TAF_TAP_location_abbreviation="FOX"
+                          TAF_TAP_location_type="station">
+            <TAF_TAP_LocationIdent>
+                <teltsi_CountryCodeISO>CH</teltsi_CountryCodeISO>
+                <teltsi_LocationPrimaryCode>5006</teltsi_LocationPrimaryCode>
+                <teltsi_PrimaryLocationName>Foxtrot</teltsi_PrimaryLocationName>
+            </TAF_TAP_LocationIdent>
+        </TAF_TAP_Location>
+    </SP_Areas>
+
+    <SP_ContextInformation>
+        <KilometreReferencePoint location="500">
+            <KM_Reference kmRef="10.0"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="1000">
+            <KM_Reference kmRef="10.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="2000">
+            <KM_Reference kmRef="11.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="3000">
+            <KM_Reference kmRef="12.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="4000">
+            <KM_Reference kmRef="13.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="5000">
+            <KM_Reference kmRef="14.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="6000">
+            <KM_Reference kmRef="15.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="6500">
+            <KM_Reference kmRef="16.0"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="7500">
+            <KM_Reference kmRef="17.0"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="8000">
+            <KM_Reference kmRef="17.5"/>
+        </KilometreReferencePoint>
+
+        <KilometreReferencePoint location="9000">
+            <KM_Reference kmRef="18.5"/>
+        </KilometreReferencePoint>
+    </SP_ContextInformation>
+</SegmentProfile>

--- a/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_TC_T50_1.xml
+++ b/sfera_mock/src/main/resources/static_sfera_resources/T50_advancement_edge_cases/SFERA_TC_T50_1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<TrainCharacteristics xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../SFERA.xsd" TC_ID="T50_1"
+                      TC_VersionMajor="1" TC_VersionMinor="0">
+    <TC_RU_ID>1185</TC_RU_ID>
+    <TC_Features trainCategoryCode="R" brakedWeightPercentage="115"/>
+</TrainCharacteristics>


### PR DESCRIPTION
* timed advancement on signaled route should also work if no VPro (and therefore no PüA) is given (cargo trains)
* if VPro is provided, we only advance by time if PüA is available and up to date
* plannedTimes are used as fallback ALWAYS (bestKnownArrival / departureTime)
* grouped and added / removed missing / duplicate unit tests for journey position view model

The assumptions have been checked again with BA.

**Integration tests will fail due to missing test data. Pass locally.**