### PR TITLE
chore(ci): implement own notify teams failure via curl

### DIFF
--- a/.github/actions/notify-teams-failure/action.yml
+++ b/.github/actions/notify-teams-failure/action.yml
@@ -1,0 +1,69 @@
+name: Notify Teams about job failure
+description: Sends an Adaptive Card to a Microsoft Teams channel with the failed step names and a direct link to the job.
+
+inputs:
+  webhook_url:
+    description: 'Microsoft Teams webhook URL'
+    required: true
+  job_key:
+    description: 'Job key of the calling job (e.g. android, ios), used to resolve the job via the API'
+    required: true
+  steps_context:
+    description: 'toJson(steps) of the calling job, used as fallback when the API is unavailable'
+    required: false
+    default: '{}'
+
+runs:
+  using: composite
+  steps:
+    - name: Send Adaptive Card
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        JOB_KEY: ${{ inputs.job_key }}
+        STEPS_CONTEXT: ${{ inputs.steps_context }}
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_NUMBER: ${{ github.run_number }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: |
+        # Resolve the current job via the API to get its direct URL and real failed step names.
+        JOB_JSON=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" 2>/dev/null \
+          | jq --arg job "$JOB_KEY" '[.jobs[] | select(.name == $job or (.name | endswith("/ " + $job)))][0] // {}' \
+          || echo '{}')
+        JOB_URL=$(jq -r '.html_url // empty' <<< "$JOB_JSON")
+        FAILED_STEPS=$(jq -r '[.steps[]? | select(.conclusion == "failure") | .name] | join(", ")' <<< "$JOB_JSON")
+        # Fallback if the API is unavailable: derive failed steps from the steps context (only steps with an id).
+        if [ -z "$FAILED_STEPS" ]; then
+          FAILED_STEPS=$(jq -r '[to_entries[] | select(.value.outcome == "failure") | .key] | join(", ")' <<< "$STEPS_CONTEXT")
+        fi
+        jq -n \
+          --arg title "❌ $WORKFLOW_NAME – $JOB_KEY failed" \
+          --arg steps "${FAILED_STEPS:-unknown}" \
+          --arg run "#$RUN_NUMBER" \
+          --arg url "${JOB_URL:-$RUN_URL}" \
+          '{
+            type: "message",
+            attachments: [{
+              contentType: "application/vnd.microsoft.card.adaptive",
+              content: {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                type: "AdaptiveCard",
+                version: "1.4",
+                msteams: { width: "Full" },
+                body: [
+                  { type: "TextBlock", size: "Medium", weight: "Bolder", color: "Attention", text: $title, wrap: true },
+                  { type: "FactSet", facts: [
+                    { title: "Failed step", value: $steps },
+                    { title: "Run", value: $run }
+                  ]},
+                  { type: "ActionSet", actions: [
+                    { type: "Action.OpenUrl", title: "Open failed job", url: $url }
+                  ]}
+                ]
+              }
+            }]
+          }' > "$RUNNER_TEMP/teams_card.json"
+        curl -fsS -H 'Content-Type: application/json' -d @"$RUNNER_TEMP/teams_card.json" "$WEBHOOK_URL"

--- a/.github/workflows/client_browserstack_base.yml
+++ b/.github/workflows/client_browserstack_base.yml
@@ -150,11 +150,11 @@ jobs:
 
       - name: Notify Microsoft Teams
         if: ${{ failure() && github.event_name == 'schedule' }}
-        uses: skitionek/notify-microsoft-teams@v1.3.0
+        uses: ./.github/actions/notify-teams-failure
         with:
           webhook_url: ${{ steps.vault-secrets.outputs.NIGHTLY_FAILURE_CHANNEL_WEBHOOK }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
+          job_key: android
+          steps_context: ${{ toJson(steps) }}
 
 
   ios:
@@ -259,8 +259,8 @@ jobs:
 
       - name: Notify Microsoft Teams
         if: ${{ failure() && github.event_name == 'schedule' }}
-        uses: skitionek/notify-microsoft-teams@v1.3.0
+        uses: ./.github/actions/notify-teams-failure
         with:
           webhook_url: ${{ steps.vault-secrets.outputs.NIGHTLY_FAILURE_CHANNEL_WEBHOOK }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
+          job_key: ios
+          steps_context: ${{ toJson(steps) }}

--- a/.github/workflows/client_browserstack_e2e.yml
+++ b/.github/workflows/client_browserstack_e2e.yml
@@ -9,6 +9,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run:
     uses: ./.github/workflows/client_browserstack_base.yml

--- a/.github/workflows/client_browserstack_integration.yml
+++ b/.github/workflows/client_browserstack_integration.yml
@@ -9,6 +9,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run:
     uses: ./.github/workflows/client_browserstack_base.yml


### PR DESCRIPTION
The existing actions do not allow for showing the steps without an id and do not allow to show the url to the failed job. Using gh API, one can receive the full summary.

I wanted that.

I copied most of it from the github action tbh for the fallback and for the card layout.